### PR TITLE
Fix a typo in Dockerfile.builder: --log-level should be --loglevel

### DIFF
--- a/build/Dockerfile.builder
+++ b/build/Dockerfile.builder
@@ -19,4 +19,4 @@ RUN chgrp auth-server-grp /app/auth-server && chown auth-server-usr /app/auth-se
 USER auth-server-usr
 WORKDIR /app
 ENTRYPOINT ["/app/auth-server"]
-CMD ["--log-level", "trace", "--address", "127.0.0.1", "--port", "10003"]
+CMD ["--loglevel", "trace", "--address", "127.0.0.1", "--port", "10003"]


### PR DESCRIPTION
Resolves #4 