### PR TITLE
New dockerfile for system-independent compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ all: build test
 docker: build
 	rm -rf build_release && mkdir -p build_release && cp -r bazel-bin/ build_release && docker build -f build/Dockerfile -t authservice:$(USER) .
 
+docker-compile-env:
+	docker build -f build/Dockerfile.interactive-compile-environment -t authservice-build-env:$(USER) .
+
 bazel-bin/src/main/auth-server:
 	bazel build $(BAZEL_FLAGS) //src/main:auth-server
 

--- a/build/Dockerfile.interactive-compile-environment
+++ b/build/Dockerfile.interactive-compile-environment
@@ -1,0 +1,12 @@
+# For a docker image that can be used interactively for build and test
+#
+# e.g. Assuming that you have cloned the project to $HOME/workspace/authservice, you can:
+# docker run -it -v $HOME/workspace/authservice:/code authservice-build-env:$USER bash
+# cd /code
+# make
+#
+FROM ubuntu:xenial
+RUN apt-get update
+RUN apt-get install git build-essential wget -y
+COPY ./build/install-bazel.sh /tmp/install-bazel.sh
+RUN /tmp/install-bazel.sh


### PR DESCRIPTION
There are link errors when compiled on MacOS, so make it easier
to compile in a system-independent way by providing a dockerfile
for building an image which contains all of the tools needed to
compile and test the project from an interactive shell inside
the container
