### PR TITLE
The check()'s request has no scheme, so don't rely on it

### DIFF
--- a/src/filters/oidc/oidc_filter.cc
+++ b/src/filters/oidc/oidc_filter.cc
@@ -194,9 +194,7 @@ google::rpc::Code OidcFilter::Process(
   auto path_parts = common::http::http::DecodePath(
       request->attributes().request().http().path());
   if (request->attributes().request().http().host() == callback_host &&
-      path_parts[0] == idp_config_.CallbackPath().path &&
-      request->attributes().request().http().scheme() ==
-          idp_config_.CallbackPath().scheme) {
+      path_parts[0] == idp_config_.CallbackPath().path) {
     return RetrieveToken(request, response, path_parts[1]);
   }
   return RedirectToIdP(response);

--- a/test/filters/oidc/oidc_filter_test.cc
+++ b/test/filters/oidc/oidc_filter_test.cc
@@ -230,7 +230,7 @@ TEST(OidcFilterTest, RetrieveToken) {
   ::envoy::service::auth::v2::CheckResponse response;
   auto httpRequest =
       request.mutable_attributes()->mutable_request()->mutable_http();
-  httpRequest->set_scheme("https");
+  httpRequest->set_scheme(""); // Seems like it should be "https", but in practice is empty
   httpRequest->set_host(callback_path.hostname);
   httpRequest->mutable_headers()->insert(
       {common::http::headers::Cookie, "__Host-acme-state-cookie=valid"});


### PR DESCRIPTION
Unclear why the request has no scheme, so perhaps we can revisit this later. For now, skipping the scheme comparison seems okay since the app should be configured to only allow https traffic for the alpha release anyway.

Resolves #24 