### PR TITLE
All namespaces and headers that use transparent_auth to authservice

### DIFF
--- a/src/common/http/headers.h
+++ b/src/common/http/headers.h
@@ -1,8 +1,8 @@
-#ifndef TRANSPARENT_AUTH_HEADERS_H
-#define TRANSPARENT_AUTH_HEADERS_H
+#ifndef AUTHSERVICE_HEADERS_H
+#define AUTHSERVICE_HEADERS_H
 #include <string>
 
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace http {
 // Standard HTTP headers
@@ -38,6 +38,6 @@ static const char *SameSiteLax = "SameSite=Lax";
 }  // namespace headers
 }  // namespace http
 }  // namespace common
-}  // namespace transparent_auth
+}  // namespace authservice
 
-#endif  // TRANSPARENT_AUTH_HEADERS_H
+#endif  // AUTHSERVICE_HEADERS_H

--- a/src/common/http/http.cc
+++ b/src/common/http/http.cc
@@ -18,7 +18,7 @@ namespace net = boost::asio;       // from <boost/asio.hpp>
 namespace ssl = boost::asio::ssl;  // from <boost/asio/ssl.hpp>
 using tcp = boost::asio::ip::tcp;  // from <boost/asio/ip/tcp.hpp>
 
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace http {
 namespace {
@@ -351,4 +351,4 @@ response_t http_impl::Post(
 
 }  // namespace http
 }  // namespace common
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/src/common/http/http.h
+++ b/src/common/http/http.h
@@ -1,5 +1,5 @@
-#ifndef TRANSPARENT_AUTH_SRC_COMMON_HTTP_HTTP_H_
-#define TRANSPARENT_AUTH_SRC_COMMON_HTTP_HTTP_H_
+#ifndef AUTHSERVICE_SRC_COMMON_HTTP_HTTP_H_
+#define AUTHSERVICE_SRC_COMMON_HTTP_HTTP_H_
 #include <array>
 #include <boost/beast.hpp>
 #include <map>
@@ -12,7 +12,7 @@
 #include "config/common/config.pb.h"
 namespace beast = boost::beast;  // from <boost/beast.hpp>
 
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace http {
 
@@ -144,6 +144,6 @@ class http_impl : public http {
 
 }  // namespace http
 }  // namespace common
-}  // namespace transparent_auth
+}  // namespace authservice
 
-#endif  // TRANSPARENT_AUTH_SRC_COMMON_HTTP_HTTP_H_
+#endif  // AUTHSERVICE_SRC_COMMON_HTTP_HTTP_H_

--- a/src/common/session/gcm_encryptor.cc
+++ b/src/common/session/gcm_encryptor.cc
@@ -3,7 +3,7 @@
 
 #include "openssl/rand.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace session {
 
@@ -123,4 +123,4 @@ GcmEncryptorPtr GcmEncryptor::Create(const std::vector<unsigned char>& key,
 
 }  // namespace session
 }  // namespace common
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/src/common/session/gcm_encryptor.h
+++ b/src/common/session/gcm_encryptor.h
@@ -1,12 +1,12 @@
-#ifndef TRANSPARENT_AUTH_SRC_COMMON_SESSION_GCM_ENCRYPTOR_H_
-#define TRANSPARENT_AUTH_SRC_COMMON_SESSION_GCM_ENCRYPTOR_H_
+#ifndef AUTHSERVICE_SRC_COMMON_SESSION_GCM_ENCRYPTOR_H_
+#define AUTHSERVICE_SRC_COMMON_SESSION_GCM_ENCRYPTOR_H_
 #include <memory>
 #include <vector>
 
 #include "absl/types/optional.h"
 #include "openssl/aead.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace session {
 
@@ -54,5 +54,5 @@ class GcmEncryptor {
 
 }  // namespace session
 }  // namespace common
-}  // namespace transparent_auth
-#endif  // TRANSPARENT_AUTH_SRC_COMMON_SESSION_GCM_ENCRYPTOR_H_
+}  // namespace authservice
+#endif  // AUTHSERVICE_SRC_COMMON_SESSION_GCM_ENCRYPTOR_H_

--- a/src/common/session/hkdf_deriver.cc
+++ b/src/common/session/hkdf_deriver.cc
@@ -4,7 +4,7 @@
 #include "openssl/digest.h"
 #include "openssl/hkdf.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace session {
 
@@ -58,4 +58,4 @@ HkdfDeriverPtr HkdfDeriver::Create(const std::vector<unsigned char>& secret,
 }
 }  // namespace session
 }  // namespace common
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/src/common/session/hkdf_deriver.h
+++ b/src/common/session/hkdf_deriver.h
@@ -1,9 +1,9 @@
-#ifndef TRANSPARENT_AUTH_SRC_COMMON_SESSION_HKDF_DERIVER_H_
-#define TRANSPARENT_AUTH_SRC_COMMON_SESSION_HKDF_DERIVER_H_
+#ifndef AUTHSERVICE_SRC_COMMON_SESSION_HKDF_DERIVER_H_
+#define AUTHSERVICE_SRC_COMMON_SESSION_HKDF_DERIVER_H_
 #include <memory>
 #include <vector>
 
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace session {
 
@@ -34,5 +34,5 @@ class HkdfDeriver {
 
 }  // namespace session
 }  // namespace common
-}  // namespace transparent_auth
-#endif  // TRANSPARENT_AUTH_SRC_COMMON_SESSION_HKDF_DERIVER_H_
+}  // namespace authservice
+#endif  // AUTHSERVICE_SRC_COMMON_SESSION_HKDF_DERIVER_H_

--- a/src/common/session/token_encryptor.cc
+++ b/src/common/session/token_encryptor.cc
@@ -3,7 +3,7 @@
 #include "src/common/session/gcm_encryptor.h"
 #include "src/common/utilities/random.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace session {
 
@@ -121,4 +121,4 @@ TokenEncryptorPtr TokenEncryptor::Create(const std::string& secret,
 
 }  // namespace session
 }  // namespace common
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/src/common/session/token_encryptor.h
+++ b/src/common/session/token_encryptor.h
@@ -1,11 +1,11 @@
-#ifndef TRANSPARENT_AUTH_SRC_COMMON_SESSION_TOKEN_ENCRYPTOR_H_
-#define TRANSPARENT_AUTH_SRC_COMMON_SESSION_TOKEN_ENCRYPTOR_H_
+#ifndef AUTHSERVICE_SRC_COMMON_SESSION_TOKEN_ENCRYPTOR_H_
+#define AUTHSERVICE_SRC_COMMON_SESSION_TOKEN_ENCRYPTOR_H_
 #include <memory>
 #include <string>
 #include "absl/types/optional.h"
 #include "src/common/session/hkdf_deriver.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace session {
 
@@ -56,5 +56,5 @@ class TokenEncryptor {
 
 }  // namespace session
 }  // namespace common
-}  // namespace transparent_auth
-#endif  // TRANSPARENT_AUTH_SRC_COMMON_SESSION_TOKEN_ENCRYPTOR_H_
+}  // namespace authservice
+#endif  // AUTHSERVICE_SRC_COMMON_SESSION_TOKEN_ENCRYPTOR_H_

--- a/src/common/utilities/random.cc
+++ b/src/common/utilities/random.cc
@@ -5,7 +5,7 @@
 #include "openssl/crypto.h"
 #include "openssl/rand.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace utilities {
 
@@ -58,4 +58,4 @@ Random RandomGenerator::Generate(size_t sz) {
 }
 }  // namespace utilities
 }  // namespace common
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/src/common/utilities/random.h
+++ b/src/common/utilities/random.h
@@ -1,12 +1,12 @@
-#ifndef TRANSPARENT_AUTH_SRC_COMMON_UTILITIES_RANDOM_H_
-#define TRANSPARENT_AUTH_SRC_COMMON_UTILITIES_RANDOM_H_
+#ifndef AUTHSERVICE_SRC_COMMON_UTILITIES_RANDOM_H_
+#define AUTHSERVICE_SRC_COMMON_UTILITIES_RANDOM_H_
 #include <memory>
 #include <string>
 #include <vector>
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace utilities {
 class Random {
@@ -74,5 +74,5 @@ class RandomGenerator {
 
 }  // namespace utilities
 }  // namespace common
-}  // namespace transparent_auth
-#endif  // TRANSPARENT_AUTH_SRC_COMMON_UTILITIES_RANDOM_H_
+}  // namespace authservice
+#endif  // AUTHSERVICE_SRC_COMMON_UTILITIES_RANDOM_H_

--- a/src/config/getconfig.cc
+++ b/src/config/getconfig.cc
@@ -11,8 +11,8 @@ using namespace std;
 using namespace google::protobuf::util;
 using namespace authservice::config;
 
-// TODO: s/namespace transparent_auth/namespace authservice/g
-namespace transparent_auth {
+// TODO: s/namespace authservice/namespace authservice/g
+namespace authservice {
 namespace config {
 
 shared_ptr<authservice::config::Config> GetConfig(
@@ -37,4 +37,4 @@ shared_ptr<authservice::config::Config> GetConfig(
   return config;
 }
 }  // namespace config
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/src/config/getconfig.cc
+++ b/src/config/getconfig.cc
@@ -11,7 +11,6 @@ using namespace std;
 using namespace google::protobuf::util;
 using namespace authservice::config;
 
-// TODO: s/namespace authservice/namespace authservice/g
 namespace authservice {
 namespace config {
 

--- a/src/config/getconfig.h
+++ b/src/config/getconfig.h
@@ -1,16 +1,16 @@
 
-#ifndef TRANSPARENT_AUTH_SRC_CONFIG_GETCONFIG_H
-#define TRANSPARENT_AUTH_SRC_CONFIG_GETCONFIG_H
+#ifndef AUTHSERVICE_SRC_CONFIG_GETCONFIG_H
+#define AUTHSERVICE_SRC_CONFIG_GETCONFIG_H
 
 #include "config/config.pb.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace config {
 
 std::shared_ptr<authservice::config::Config> GetConfig(
     const std::string& configFile);
 
 }  // namespace config
-}  // namespace transparent_auth
+}  // namespace authservice
 
-#endif  // TRANSPARENT_AUTH_SRC_CONFIG_GETCONFIG_H
+#endif  // AUTHSERVICE_SRC_CONFIG_GETCONFIG_H

--- a/src/filters/filter.h
+++ b/src/filters/filter.h
@@ -1,12 +1,12 @@
-#ifndef TRANSPARENT_AUTH_SRC_FILTERS_FILTER_H_
-#define TRANSPARENT_AUTH_SRC_FILTERS_FILTER_H_
+#ifndef AUTHSERVICE_SRC_FILTERS_FILTER_H_
+#define AUTHSERVICE_SRC_FILTERS_FILTER_H_
 #include "absl/strings/string_view.h"
 #include "envoy/service/auth/v2/external_auth.grpc.pb.h"
 #include "google/rpc/code.pb.h"
 
 using namespace envoy::service::auth::v2;
 
-namespace transparent_auth {
+namespace authservice {
 namespace filters {
 /** @brief Filter defines an abstract class for processing requests.
  *
@@ -49,6 +49,6 @@ class Filter {
   virtual absl::string_view Name() const = 0;
 };
 }  // namespace filters
-}  // namespace transparent_auth
+}  // namespace authservice
 
-#endif  // TRANSPARENT_AUTH_SRC_FILTERS_FILTER_H_
+#endif  // AUTHSERVICE_SRC_FILTERS_FILTER_H_

--- a/src/filters/oidc/oidc_filter.cc
+++ b/src/filters/oidc/oidc_filter.cc
@@ -13,7 +13,7 @@ namespace http = beast::http;      // from <boost/beast/http.hpp>
 namespace net = boost::asio;       // from <boost/asio.hpp>
 using tcp = boost::asio::ip::tcp;  // from <boost/asio/ip/tcp.hpp>
 
-namespace transparent_auth {
+namespace authservice {
 namespace filters {
 namespace oidc {
 
@@ -394,4 +394,4 @@ absl::string_view OidcFilter::Name() const { return filter_name_; }
 
 }  // namespace oidc
 }  // namespace filters
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/src/filters/oidc/oidc_filter.h
+++ b/src/filters/oidc/oidc_filter.h
@@ -1,5 +1,5 @@
-#ifndef TRANSPARENT_AUTH_SRC_FILTERS_OIDC_OIDC_FILTER_H_
-#define TRANSPARENT_AUTH_SRC_FILTERS_OIDC_OIDC_FILTER_H_
+#ifndef AUTHSERVICE_SRC_FILTERS_OIDC_OIDC_FILTER_H_
+#define AUTHSERVICE_SRC_FILTERS_OIDC_OIDC_FILTER_H_
 #include "config/oidc/config.pb.h"
 #include "external/com_google_googleapis/google/rpc/code.pb.h"
 #include "src/common/http/http.h"
@@ -7,7 +7,7 @@
 #include "src/filters/filter.h"
 #include "src/filters/oidc/token_response.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace filters {
 namespace oidc {
 
@@ -123,6 +123,6 @@ class OidcFilter final : public filters::Filter {
 
 }  // namespace oidc
 }  // namespace filters
-}  // namespace transparent_auth
+}  // namespace authservice
 
-#endif  // TRANSPARENT_AUTH_SRC_FILTERS_OIDC_OIDC_FILTER_H_
+#endif  // AUTHSERVICE_SRC_FILTERS_OIDC_OIDC_FILTER_H_

--- a/src/filters/oidc/state_cookie_codec.cc
+++ b/src/filters/oidc/state_cookie_codec.cc
@@ -2,7 +2,7 @@
 #include <sstream>
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
-namespace transparent_auth {
+namespace authservice {
 namespace filters {
 namespace oidc {
 namespace {
@@ -24,4 +24,4 @@ StateCookieCodec::Decode(absl::string_view value) {
 
 }  // namespace oidc
 }  // namespace filters
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/src/filters/oidc/state_cookie_codec.h
+++ b/src/filters/oidc/state_cookie_codec.h
@@ -1,10 +1,10 @@
-#ifndef TRANSPARENT_AUTH_SRC_FILTERS_OIDC_STATE_COOKIE_CODEC_H_
-#define TRANSPARENT_AUTH_SRC_FILTERS_OIDC_STATE_COOKIE_CODEC_H_
+#ifndef AUTHSERVICE_SRC_FILTERS_OIDC_STATE_COOKIE_CODEC_H_
+#define AUTHSERVICE_SRC_FILTERS_OIDC_STATE_COOKIE_CODEC_H_
 
 #include <map>
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
-namespace transparent_auth {
+namespace authservice {
 namespace filters {
 namespace oidc {
 /**
@@ -30,5 +30,5 @@ class StateCookieCodec {
 
 }  // namespace oidc
 }  // namespace filters
-}  // namespace transparent_auth
-#endif  // TRANSPARENT_AUTH_SRC_FILTERS_OIDC_STATE_COOKIE_CODEC_H_
+}  // namespace authservice
+#endif  // AUTHSERVICE_SRC_FILTERS_OIDC_STATE_COOKIE_CODEC_H_

--- a/src/filters/oidc/token_response.cc
+++ b/src/filters/oidc/token_response.cc
@@ -5,7 +5,7 @@
 #include "jwt_verify_lib/verify.h"
 #include "spdlog/spdlog.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace filters {
 namespace oidc {
 namespace {
@@ -94,4 +94,4 @@ absl::optional<TokenResponse> TokenResponseParserImpl::Parse(
 
 }  // namespace oidc
 }  // namespace filters
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/src/filters/oidc/token_response.h
+++ b/src/filters/oidc/token_response.h
@@ -1,11 +1,11 @@
-#ifndef TRANSPARENT_AUTH_SRC_FILTERS_OIDC_TOKEN_RESPONSE_H_
-#define TRANSPARENT_AUTH_SRC_FILTERS_OIDC_TOKEN_RESPONSE_H_
+#ifndef AUTHSERVICE_SRC_FILTERS_OIDC_TOKEN_RESPONSE_H_
+#define AUTHSERVICE_SRC_FILTERS_OIDC_TOKEN_RESPONSE_H_
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 #include "jwt_verify_lib/jwks.h"
 #include "jwt_verify_lib/jwt.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace filters {
 namespace oidc {
 
@@ -62,5 +62,5 @@ class TokenResponseParserImpl final : public TokenResponseParser {
 
 }  // namespace oidc
 }  // namespace filters
-}  // namespace transparent_auth
-#endif  // TRANSPARENT_AUTH_SRC_FILTERS_OIDC_TOKEN_RESPONSE_H_
+}  // namespace authservice
+#endif  // AUTHSERVICE_SRC_FILTERS_OIDC_TOKEN_RESPONSE_H_

--- a/src/filters/pipe.cc
+++ b/src/filters/pipe.cc
@@ -2,7 +2,7 @@
 #include "google/rpc/code.pb.h"
 #include "grpcpp/support/status.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace filters {
 namespace {
 const char *filter_name_ = "pipe";
@@ -44,4 +44,4 @@ google::rpc::Code Pipe::Process(
 
 absl::string_view Pipe::Name() const { return filter_name_; }
 }  // namespace filters
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/src/filters/pipe.h
+++ b/src/filters/pipe.h
@@ -1,12 +1,12 @@
-#ifndef TRANSPARENT_AUTH_SRC_FILTERS_PIPE_H_
-#define TRANSPARENT_AUTH_SRC_FILTERS_PIPE_H_
+#ifndef AUTHSERVICE_SRC_FILTERS_PIPE_H_
+#define AUTHSERVICE_SRC_FILTERS_PIPE_H_
 #include <memory>
 #include <mutex>
 #include <vector>
 
 #include "src/filters/filter.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace filters {
 
 typedef std::unique_ptr<Filter> FilterPtr;
@@ -28,6 +28,6 @@ class Pipe final : public Filter {
 };
 
 }  // namespace filters
-}  // namespace transparent_auth
+}  // namespace authservice
 
-#endif  // TRANSPARENT_AUTH_SRC_FILTERS_PIPE_TEST_H_
+#endif  // AUTHSERVICE_SRC_FILTERS_PIPE_TEST_H_

--- a/src/main/auth-server.cc
+++ b/src/main/auth-server.cc
@@ -18,7 +18,7 @@
 using grpc::Server;
 using grpc::ServerBuilder;
 
-namespace transparent_auth {
+namespace authservice {
 namespace service {
 
 spdlog::level::level_enum GetConfiguredLogLevel(
@@ -69,7 +69,7 @@ void RunServer(const std::shared_ptr<authservice::config::Config>& config) {
 }
 
 }  // namespace service
-}  // namespace transparent_auth
+}  // namespace authservice
 
 ABSL_FLAG(std::string, filter_config, "/etc/authservice/config.json",
           "path to filter config");
@@ -83,10 +83,10 @@ int main(int argc, char** argv) {
 
   try {
     auto config =
-        transparent_auth::config::GetConfig(absl::GetFlag(FLAGS_filter_config));
+        authservice::config::GetConfig(absl::GetFlag(FLAGS_filter_config));
     console->set_level(
-        transparent_auth::service::GetConfiguredLogLevel(config));
-    transparent_auth::service::RunServer(config);
+        authservice::service::GetConfiguredLogLevel(config));
+    authservice::service::RunServer(config);
   } catch (const std::exception& e) {
     spdlog::error("{}: Unexpected error: {}", __func__, e.what());
     return EXIT_FAILURE;

--- a/src/service/serviceimpl.cc
+++ b/src/service/serviceimpl.cc
@@ -6,7 +6,7 @@
 #include "src/filters/oidc/oidc_filter.h"
 #include "src/filters/pipe.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace service {
 
 AuthServiceImpl::AuthServiceImpl(
@@ -71,4 +71,4 @@ AuthServiceImpl::AuthServiceImpl(
   return ::grpc::Status(::grpc::StatusCode::INTERNAL, "internal error");
 }
 }  // namespace service
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/src/service/serviceimpl.h
+++ b/src/service/serviceimpl.h
@@ -1,5 +1,5 @@
-#ifndef TRANSPARENT_AUTH_SERVICEIMPL_H
-#define TRANSPARENT_AUTH_SERVICEIMPL_H
+#ifndef AUTHSERVICE_SERVICEIMPL_H
+#define AUTHSERVICE_SERVICEIMPL_H
 #include "config/config.pb.h"
 #include "envoy/service/auth/v2/external_auth.grpc.pb.h"
 #include "src/filters/oidc/token_response.h"
@@ -7,7 +7,7 @@
 
 using namespace envoy::service::auth::v2;
 
-namespace transparent_auth {
+namespace authservice {
 namespace service {
 
 class AuthServiceImpl final : public Authorization::Service {
@@ -22,6 +22,6 @@ class AuthServiceImpl final : public Authorization::Service {
       ::envoy::service::auth::v2::CheckResponse* response) override;
 };
 }  // namespace service
-}  // namespace transparent_auth
+}  // namespace authservice
 
-#endif  // TRANSPARENT_AUTH_SERVICEIMPL_H
+#endif  // AUTHSERVICE_SERVICEIMPL_H

--- a/test/common/http/http_test.cc
+++ b/test/common/http/http_test.cc
@@ -3,7 +3,7 @@
 #include "gtest/gtest.h"
 #include "src/common/http/headers.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace http {
 namespace {
@@ -203,4 +203,4 @@ TEST(Http, DecodePath) {
 
 }  // namespace http
 }  // namespace common
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/test/common/http/mocks.h
+++ b/test/common/http/mocks.h
@@ -1,8 +1,8 @@
-#ifndef TRANSPARENT_AUTH_TEST_COMMON_HTTP_MOCKS_H_
-#define TRANSPARENT_AUTH_TEST_COMMON_HTTP_MOCKS_H_
+#ifndef AUTHSERVICE_TEST_COMMON_HTTP_MOCKS_H_
+#define AUTHSERVICE_TEST_COMMON_HTTP_MOCKS_H_
 #include "gmock/gmock.h"
 #include "src/common/http/http.h"
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace http {
 class http_mock : public http {
@@ -15,5 +15,5 @@ class http_mock : public http {
 };
 }  // namespace http
 }  // namespace common
-}  // namespace transparent_auth
-#endif  // TRANSPARENT_AUTH_TEST_COMMON_HTTP_MOCKS_H_
+}  // namespace authservice
+#endif  // AUTHSERVICE_TEST_COMMON_HTTP_MOCKS_H_

--- a/test/common/session/gcm_encryptor_test.cc
+++ b/test/common/session/gcm_encryptor_test.cc
@@ -2,7 +2,7 @@
 
 #include "gtest/gtest.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace session {
 
@@ -49,4 +49,4 @@ TEST(GcmEncryptorTest, SealAndOpen) {
 
 }  // namespace session
 }  // namespace common
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/test/common/session/hkdf_deriver_test.cc
+++ b/test/common/session/hkdf_deriver_test.cc
@@ -1,7 +1,7 @@
 #include "src/common/session/hkdf_deriver.h"
 #include "gtest/gtest.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace session {
 
@@ -38,4 +38,4 @@ TEST(HkdfDeriverTest, DeriveKey) {
 
 }  // namespace session
 }  // namespace common
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/test/common/session/mocks.h
+++ b/test/common/session/mocks.h
@@ -1,9 +1,9 @@
-#ifndef TRANSPARENT_AUTH_TEST_COMMON_SESSION_MOCKS_H_
-#define TRANSPARENT_AUTH_TEST_COMMON_SESSION_MOCKS_H_
+#ifndef AUTHSERVICE_TEST_COMMON_SESSION_MOCKS_H_
+#define AUTHSERVICE_TEST_COMMON_SESSION_MOCKS_H_
 #include "gmock/gmock.h"
 #include "src/common/session/token_encryptor.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace session {
 class TokenEncryptorMock final : public TokenEncryptor {
@@ -14,6 +14,6 @@ class TokenEncryptorMock final : public TokenEncryptor {
 };
 }  // namespace session
 }  // namespace common
-}  // namespace transparent_auth
+}  // namespace authservice
 
-#endif  // TRANSPARENT_AUTH_TEST_COMMON_SESSION_MOCKS_H_
+#endif  // AUTHSERVICE_TEST_COMMON_SESSION_MOCKS_H_

--- a/test/common/session/token_encryptor_test.cc
+++ b/test/common/session/token_encryptor_test.cc
@@ -3,7 +3,7 @@
 
 #include "gtest/gtest.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace session {
 
@@ -25,4 +25,4 @@ TEST(TokenEncryptorTest, SealAndOpen) {
 }
 }  // namespace session
 }  // namespace common
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/test/common/utilities/random_test.cc
+++ b/test/common/utilities/random_test.cc
@@ -3,7 +3,7 @@
 #include "gtest/gtest.h"
 #include "openssl/rand.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace common {
 namespace utilities {
 
@@ -26,4 +26,4 @@ TEST(Random, Rand) {
 
 }  // namespace utilities
 }  // namespace common
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/test/config/getconfig_test.cc
+++ b/test/config/getconfig_test.cc
@@ -1,7 +1,7 @@
 #include "src/config/getconfig.h"
 #include "gtest/gtest.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace config {
 
 TEST(GetConfigTest, ReturnsTheConfig) {
@@ -58,4 +58,4 @@ TEST(GetConfigTest,
 }
 
 }  // namespace config
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/test/filters/oidc/mocks.h
+++ b/test/filters/oidc/mocks.h
@@ -1,8 +1,8 @@
-#ifndef TRANSPARENT_AUTH_TEST_FILTERS_OIDC_MOCKS_H_
-#define TRANSPARENT_AUTH_TEST_FILTERS_OIDC_MOCKS_H_
+#ifndef AUTHSERVICE_TEST_FILTERS_OIDC_MOCKS_H_
+#define AUTHSERVICE_TEST_FILTERS_OIDC_MOCKS_H_
 #include "gmock/gmock.h"
 #include "src/filters/oidc/token_response.h"
-namespace transparent_auth {
+namespace authservice {
 namespace filters {
 namespace oidc {
 class TokenResponseParserMock final : public TokenResponseParser {
@@ -13,5 +13,5 @@ class TokenResponseParserMock final : public TokenResponseParser {
 };
 }  // namespace oidc
 }  // namespace filters
-}  // namespace transparent_auth
-#endif  // TRANSPARENT_AUTH_TEST_FILTERS_OIDC_MOCKS_H_
+}  // namespace authservice
+#endif  // AUTHSERVICE_TEST_FILTERS_OIDC_MOCKS_H_

--- a/test/filters/oidc/oidc_filter_test.cc
+++ b/test/filters/oidc/oidc_filter_test.cc
@@ -9,7 +9,7 @@
 #include "test/common/session/mocks.h"
 #include "test/filters/oidc/mocks.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace filters {
 namespace oidc {
 
@@ -924,4 +924,4 @@ TEST_F(OidcFilterTest, RetrieveTokenInvalidResponse) {
 
 }  // namespace oidc
 }  // namespace filters
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/test/filters/oidc/state_cookie_codec_test.cc
+++ b/test/filters/oidc/state_cookie_codec_test.cc
@@ -2,7 +2,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace filters {
 namespace oidc {
 TEST(StateCookieCodecTest, Encode) {
@@ -27,4 +27,4 @@ TEST(StateCookieCodecTest, Decode) {
 }
 }  // namespace oidc
 }  // namespace filters
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/test/filters/oidc/token_response_test.cc
+++ b/test/filters/oidc/token_response_test.cc
@@ -2,7 +2,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace filters {
 namespace oidc {
 namespace {
@@ -111,4 +111,4 @@ TEST(TokenResponseParser, Parse) {
 }
 }  // namespace oidc
 }  // namespace filters
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/test/filters/pipe_test.cc
+++ b/test/filters/pipe_test.cc
@@ -1,7 +1,7 @@
 #include "src/filters/pipe.h"
 #include "gtest/gtest.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace filters {
 TEST(PipeTest, Name) {
   Pipe pipe;
@@ -9,4 +9,4 @@ TEST(PipeTest, Name) {
 }
 
 }  // namespace filters
-}  // namespace transparent_auth
+}  // namespace authservice

--- a/test/service/serviceimpl_test.cc
+++ b/test/service/serviceimpl_test.cc
@@ -2,11 +2,11 @@
 #include "gtest/gtest.h"
 #include "src/config/getconfig.h"
 
-namespace transparent_auth {
+namespace authservice {
 namespace service {
 TEST(ServiceImplTest, Check) {
   AuthServiceImpl service(
-      transparent_auth::config::GetConfig("test/fixtures/valid-config.json"));
+      authservice::config::GetConfig("test/fixtures/valid-config.json"));
   ::envoy::service::auth::v2::CheckRequest request;
   ::envoy::service::auth::v2::CheckResponse response;
 
@@ -23,4 +23,4 @@ TEST(ServiceImplTest, Check) {
 }
 
 }  // namespace service
-}  // namespace transparent_auth
+}  // namespace authservice


### PR DESCRIPTION
Fixes #45 
Any time I saw transparent_auth as a header, namespace, or in the comments I changed it to authservice in both the src and test folders. I also followed the same coding conventions. 