### PR TITLE
33 fix todos

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,7 +15,6 @@ load("@envoy//bazel:api_binding.bzl", "envoy_api_binding")
 
 envoy_api_binding()
 
-
 load("@envoy//bazel:api_repositories.bzl", "envoy_api_dependencies")
 
 envoy_api_dependencies()
@@ -123,7 +122,7 @@ http_archive(
 
 git_repository(
     name = "com_github_google_jwt_verify_lib",
-    commit = "0f14d43f20381cfae0469cb2309b2e220c0f0ea3",
+    commit = "945805866007edb9d2760915abaa672ed8b7da86",
     remote = "https://github.com/google/jwt_verify_lib",
 )
 

--- a/build/Dockerfile.builder
+++ b/build/Dockerfile.builder
@@ -7,7 +7,7 @@ RUN chmod +x /build/install-bazel.sh && /build/install-bazel.sh
 FROM bazel-builder as auth-builder
 COPY . /src
 WORKDIR /src
-RUN bazel build //...
+RUN make bazel-bin/src/main/auth-server
 
 # Create our final auth-server container image.
 FROM debian:buster

--- a/build/install-bazel.sh
+++ b/build/install-bazel.sh
@@ -6,7 +6,7 @@ BAZEL_VERSION="0.29.1"
 BAZEL_INSTALLER_SIG="f87f0057cd7d6666e4d371267fbe27a9ed47f42e6663694a1cd755c8c6858baf"
 
 # Required packages.
-apt-get update && apt-get upgrade -y && apt-get install -y wget pkg-config zip g++ zlib1g-dev unzip python3 git
+apt-get update && apt-get upgrade -y && apt-get install -y wget pkg-config zip g++ zlib1g-dev unzip python3 git make
 
 # Bazel download, check and installation
 mkdir -p /tmp/bazel-install-${BAZEL_VERSION}

--- a/config/oidc/config.proto
+++ b/config/oidc/config.proto
@@ -29,4 +29,6 @@ message OIDCConfig {
     string cookie_name_prefix = 11;
     TokenConfig id_token = 12 [(validate.rules).message.required = true];
     TokenConfig access_token = 13;
+    // the timeout in seconds for performing an authentication with an IdP.
+    uint32 timeout = 14 [(validate.rules).uint32.gte = 30];
 }

--- a/config/oidc/config.proto
+++ b/config/oidc/config.proto
@@ -17,14 +17,16 @@ message TokenConfig {
 message OIDCConfig {
     common.Endpoint authorization = 1 [(validate.rules).message.required = true];
     common.Endpoint token = 2 [(validate.rules).message.required = true];
-    // TODO: make JWKS config oneof
-    common.Endpoint jwks_uri = 3;
-    string jwks = 4;
+    oneof jwks_config {
+        option (validate.required) = true;
+        common.Endpoint jwks_uri = 3;
+        string jwks = 4;
+    }
     common.Endpoint callback = 5 [(validate.rules).message.required = true];
     string client_id = 6 [(validate.rules).string.min_len = 1];
     string client_secret = 7 [(validate.rules).string.min_len = 1];
     repeated string scopes = 8;
-    string landing_page = 9 [(validate.rules).string.min_len = 1]; // TODO: use [(validate.rules).string.uri_ref = true] when implemented
+    string landing_page = 9 [(validate.rules).string.min_len = 1]; // TODO: use [(validate.rules).string.uri_ref = true] when implemented for C/C++.
     string cryptor_secret = 10 [(validate.rules).string.min_len = 1];
     string cookie_name_prefix = 11;
     TokenConfig id_token = 12 [(validate.rules).message.required = true];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,9 @@ services:
     volumes:
       - ./run/envoy:/etc/envoy:ro
   auth:
-    image: authservice
+    build:
+      dockerfile: build/Dockerfile.builder
+      context: ./
     command: ["-log_level", "trace", "-address", "0.0.0.0", "-port", "10004", "-filter_config", "/etc/authservice/config.json"]
     ports:
       - "10004:10004"

--- a/src/common/http/headers.h
+++ b/src/common/http/headers.h
@@ -33,6 +33,7 @@ static const char *Secure = "Secure";
 static const char *HttpOnly = "HttpOnly";
 static const char *SameSiteStrict = "SameSite=Strict";
 static const char *SameSiteLax = "SameSite=Lax";
+static const char *MaxAge = "Max-Age";
 }  // namespace SetCookieDirectives
 
 }  // namespace headers

--- a/src/common/session/token_encryptor.cc
+++ b/src/common/session/token_encryptor.cc
@@ -69,7 +69,6 @@ std::vector<unsigned char> TokenEncryptorImpl::EncryptInternal(
 }
 
 std::string TokenEncryptorImpl::Encrypt(const std::string& token) {
-  // TODO add a token expiry.
   auto nonce = generator_.Generate(NONCE_SIZE);
   std::vector<unsigned char> nonce_vec(nonce.Begin(), nonce.End());
   auto derivedKey = deriver_->Derive(KeySize(), nonce_vec);
@@ -87,7 +86,6 @@ std::string TokenEncryptorImpl::Encrypt(const std::string& token) {
 }
 
 absl::optional<std::string> TokenEncryptorImpl::Decrypt(
-    // TODO add a token expiry.
     const std::string& ciphertext) {
   // UrlBase64 decode the token
   std::string decoded;

--- a/src/filters/oidc/BUILD
+++ b/src/filters/oidc/BUILD
@@ -38,6 +38,7 @@ xx_library(
         "//src/filters/oidc:state_cookie_codec",
         "//src/filters/oidc:token_response",
         "@boost//:all",
+        "@com_github_abseil-cpp//absl/time:time",
         "@com_github_gabime_spdlog//:spdlog",
     ],
 )

--- a/src/filters/oidc/oidc_filter.cc
+++ b/src/filters/oidc/oidc_filter.cc
@@ -24,8 +24,6 @@ namespace oidc {
 namespace {
 const char *filter_name_ = "oidc";
 const char *mandatory_scope_ = "openid";
-const std::string bearer_prefix_ = "Bearer";
-const int64_t five_minutes_as_seconds = 5 * 60;
 
 const std::map<const char *, const char *> standard_headers = {
     {common::http::headers::CacheControl,
@@ -109,7 +107,6 @@ void OidcFilter::SetStateCookie(
     ::google::protobuf::RepeatedPtrField<
         ::envoy::api::v2::core::HeaderValueOption> *headers,
     absl::string_view value, int64_t timeout) {
-  // TODO: make state cookie timeout configurable.
   auto timeout_directive = EncodeCookieTimeoutDirective(timeout);
   std::set<absl::string_view> token_set_cookie_header_directives =
       {common::http::headers::SetCookieDirectives::HttpOnly,
@@ -171,7 +168,7 @@ google::rpc::Code OidcFilter::RedirectToIdP(
   auto state_token = codec.Encode(state, nonce);
   auto encrypted_state_token = cryptor_->Encrypt(state_token);
   SetStateCookie(response->mutable_denied_response()->mutable_headers(),
-                 encrypted_state_token, five_minutes_as_seconds);
+                 encrypted_state_token, idp_config_.timeout());
   return google::rpc::Code::UNAUTHENTICATED;
 }
 

--- a/src/filters/oidc/oidc_filter.cc
+++ b/src/filters/oidc/oidc_filter.cc
@@ -314,8 +314,9 @@ google::rpc::Code OidcFilter::RetrieveToken(
     ::grpc::Status error(::grpc::StatusCode::UNKNOWN, "IdP connection error");
     return google::rpc::Code::UNKNOWN;
   } else {
-    // TODO: fill in nonce from state and validate JWT.
-    auto token = parser_->Parse("", retrieve_token_response->body());
+    auto token = parser_->Parse(idp_config_.client_id(),
+        std::string(state_and_nonce->second.data(), state_and_nonce->second.size()),
+        retrieve_token_response->body());
     if (!token.has_value()) {
       spdlog::info("{}: Invalid token response", __func__);
       ::grpc::Status error(::grpc::StatusCode::INVALID_ARGUMENT,

--- a/src/filters/oidc/oidc_filter.h
+++ b/src/filters/oidc/oidc_filter.h
@@ -52,15 +52,23 @@ class OidcFilter final : public filters::Filter {
       absl::string_view redirect_url,
       ::envoy::service::auth::v2::CheckResponse *response);
 
+  /** @brief Encode the given timeout as a cookie Max-Age directive.
+   *
+   * @param timeout the time out in seconds.
+   * @return the encoded cookie directive.
+   */
+  static std::string EncodeCookieTimeoutDirective(int64_t timeout);
+
   /** @brief Set state cookie.
    *
    * @param headers The headers to add to.
    * @param value The value of the state cookie.
+   * @param timeout The number of second the cookie is valid for
    */
   void SetStateCookie(
       ::google::protobuf::RepeatedPtrField<
           ::envoy::api::v2::core::HeaderValueOption> *headers,
-      absl::string_view value);
+      absl::string_view value, int64_t timeout);
 
   /** @brief Extract the requested cookie from the given headers
    *

--- a/src/filters/oidc/token_response.cc
+++ b/src/filters/oidc/token_response.cc
@@ -123,7 +123,7 @@ absl::optional<TokenResponse> TokenResponseParserImpl::Parse(
   auto expiry = static_cast<int64_t>(id_token.exp_);
   auto expires_in_iter = fields.find(expires_in_field);
   if (expires_in_iter != fields.end()) {
-    auto expires_in = int64_t(access_token_iter->second.number_value());
+    auto expires_in = int64_t(expires_in_iter->second.number_value());
     if (expires_in <= 0) {
       spdlog::info("{}: invalid `expired_in` token response field", __func__);
       return absl::nullopt;

--- a/src/filters/oidc/token_response.h
+++ b/src/filters/oidc/token_response.h
@@ -1,6 +1,5 @@
 #ifndef TRANSPARENT_AUTH_SRC_FILTERS_OIDC_TOKEN_RESPONSE_H_
 #define TRANSPARENT_AUTH_SRC_FILTERS_OIDC_TOKEN_RESPONSE_H_
-#include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 #include "jwt_verify_lib/jwks.h"
 #include "jwt_verify_lib/jwt.h"
@@ -35,12 +34,14 @@ class TokenResponseParser {
   virtual ~TokenResponseParser(){};
   /**
    * Parse the given token response.
-   * @param nonce the expected none that should be present in the id_token
+   * @param client_id the expected client_id that should be present in the id_token `aud` field.
+   * @param nonce the expected nonce that should be present in the id_token
    * @param raw the raw response to be parsed
    * @return either an empty result indicating an error or a TokenResponse.
    */
-  virtual absl::optional<TokenResponse> Parse(absl::string_view nonce,
-                                              absl::string_view raw) const = 0;
+  virtual absl::optional<TokenResponse> Parse(const std::string &client_id,
+                                              const std::string &nonce,
+                                              const std::string &raw) const = 0;
 };
 
 /**
@@ -53,8 +54,9 @@ class TokenResponseParserImpl final : public TokenResponseParser {
 
  public:
   TokenResponseParserImpl(google::jwt_verify::JwksPtr keys);
-  absl::optional<TokenResponse> Parse(absl::string_view nonce,
-                                      absl::string_view raw) const override;
+  absl::optional<TokenResponse> Parse(const std::string &client_id,
+                                      const std::string &nonce,
+                                      const std::string &raw) const override;
 };
 
 }  // namespace oidc

--- a/src/filters/oidc/token_response.h
+++ b/src/filters/oidc/token_response.h
@@ -19,12 +19,15 @@ class TokenResponse {
  private:
   google::jwt_verify::Jwt id_token_;
   std::string access_token_;
+  int64_t expiry_;
 
  public:
   TokenResponse(const google::jwt_verify::Jwt &id_token);
   void SetAccessToken(absl::string_view access_token);
+  void SetExpiry(int64_t expiry);
   const google::jwt_verify::Jwt &IDToken() const;
-  const std::string &AccessToken() const;
+  absl::optional<const std::string> AccessToken() const;
+  absl::optional<int64_t> Expiry() const;
 };
 
 class TokenResponseParser;

--- a/test/config/getconfig_test.cc
+++ b/test/config/getconfig_test.cc
@@ -43,6 +43,7 @@ TEST(GetConfigTest, ReturnsTheConfig) {
   ASSERT_EQ(oidc.landing_page(), "page");
   ASSERT_EQ(oidc.cryptor_secret(), "some-secret");
   ASSERT_EQ(oidc.cookie_name_prefix(), "my-app");
+  ASSERT_EQ(oidc.timeout(), 300);
 }
 
 TEST(GetConfigTest, ValidateOidcConfigThrowsForInvalidConfig) {

--- a/test/config/getconfig_test.cc
+++ b/test/config/getconfig_test.cc
@@ -27,8 +27,6 @@ TEST(GetConfigTest, ReturnsTheConfig) {
   ASSERT_EQ(oidc.jwks_uri().path(), "/path1");
   ASSERT_EQ(oidc.jwks_uri().port(), 443);
 
-  ASSERT_EQ(oidc.jwks(), "some-jwks");
-
   ASSERT_EQ(oidc.callback().scheme(), "https");
   ASSERT_EQ(oidc.callback().hostname(), "google4");
   ASSERT_EQ(oidc.callback().path(), "/path4");

--- a/test/filters/oidc/mocks.h
+++ b/test/filters/oidc/mocks.h
@@ -7,9 +7,10 @@ namespace filters {
 namespace oidc {
 class TokenResponseParserMock final : public TokenResponseParser {
  public:
-  MOCK_CONST_METHOD2(Parse,
-                     absl::optional<TokenResponse>(absl::string_view nonce,
-                                                   absl::string_view raw));
+  MOCK_CONST_METHOD3(Parse,
+                     absl::optional<TokenResponse>(const std::string &client_id,
+                         const std::string &nonce,
+                         const std::string &raw));
 };
 }  // namespace oidc
 }  // namespace filters

--- a/test/filters/oidc/oidc_filter_test.cc
+++ b/test/filters/oidc/oidc_filter_test.cc
@@ -251,7 +251,7 @@ TEST_F(OidcFilterTest, RetrieveToken) {
   google::jwt_verify::Jwt jwt = {};
   auto parser_mock = std::make_shared<TokenResponseParserMock>();
   auto cryptor_mock = std::make_shared<common::session::TokenEncryptorMock>();
-  EXPECT_CALL(*parser_mock, Parse(::testing::_, ::testing::_))
+  EXPECT_CALL(*parser_mock, Parse(config_.client_id(), ::testing::_, ::testing::_))
       .WillOnce(::testing::Return(absl::make_optional<TokenResponse>(jwt)));
   common::http::http_mock *mocked_http = new common::http::http_mock();
   auto raw_http = common::http::response_t(
@@ -576,7 +576,7 @@ TEST_F(OidcFilterTest, RetrieveTokenBrokenPipe) {
 TEST_F(OidcFilterTest, RetrieveTokenInvalidResponse) {
   auto parser_mock = std::make_shared<TokenResponseParserMock>();
   auto cryptor_mock = std::make_shared<common::session::TokenEncryptorMock>();
-  EXPECT_CALL(*parser_mock, Parse(::testing::_, ::testing::_))
+  EXPECT_CALL(*parser_mock, Parse(config_.client_id(), ::testing::_, ::testing::_))
       .WillOnce(::testing::Return(absl::nullopt));
   common::http::http_mock *http_mock = new common::http::http_mock();
   auto raw_http = common::http::response_t(

--- a/test/filters/oidc/oidc_filter_test.cc
+++ b/test/filters/oidc/oidc_filter_test.cc
@@ -132,7 +132,7 @@ TEST_F(OidcFilterTest, NoAuthorization) {
                 common::http::headers::PragmaDirectives::NoCache);
     } else if (iter.header().key() == common::http::headers::SetCookie) {
       ASSERT_EQ(iter.header().value(),
-                "cookie-prefix-authservice-state-cookie=encrypted; HttpOnly; Path=/; "
+                "cookie-prefix-authservice-state-cookie=encrypted; HttpOnly; Max-Age=300; Path=/; "
                 "SameSite=Lax; Secure");
     } else {
       FAIL();  // Unexpected header!
@@ -171,7 +171,7 @@ TEST_F(OidcFilterTest, InvalidCookies) {
                 common::http::headers::PragmaDirectives::NoCache);
     } else if (iter.header().key() == common::http::headers::SetCookie) {
       ASSERT_EQ(iter.header().value(),
-                "cookie-prefix-authservice-state-cookie=encrypted; HttpOnly; Path=/; "
+                "cookie-prefix-authservice-state-cookie=encrypted; HttpOnly; Max-Age=300; Path=/; "
                 "SameSite=Lax; Secure");
     } else {
       FAIL();  // Unexpected header!
@@ -214,7 +214,7 @@ TEST_F(OidcFilterTest, InvalidSessionToken) {
                 common::http::headers::PragmaDirectives::NoCache);
     } else if (iter.header().key() == common::http::headers::SetCookie) {
       ASSERT_EQ(iter.header().value(),
-                "cookie-prefix-authservice-state-cookie=encrypted; HttpOnly; Path=/; "
+                "cookie-prefix-authservice-state-cookie=encrypted; HttpOnly; Max-Age=300; Path=/; "
                 "SameSite=Lax; Secure");
     } else {
       FAIL();  // Unexpected header!
@@ -291,11 +291,11 @@ TEST_F(OidcFilterTest, RetrieveToken) {
       ASSERT_EQ(iter.header().value(),
                 common::http::headers::PragmaDirectives::NoCache);
     } else if (iter.header().key() == common::http::headers::SetCookie) {
-      ASSERT_TRUE((iter.header().value() == "cookie-prefix-authservice-id-token-session-"
-                                            "cookie=encryptedtoken; HttpOnly; "
-                                            "Path=/; SameSite=Lax; Secure") ||
-                  (iter.header().value() == "cookie-prefix-authservice-state-cookie=deleted; "
-                                            "HttpOnly; Path=/; SameSite=Lax; "
+      auto val = iter.header().value();
+      std::regex id_token_regex("cookie-prefix-authservice-id-token-session-cookie=encryptedtoken; HttpOnly; Max-Age=[0-9]+; Path=/; SameSite=Lax; Secure");
+      ASSERT_TRUE(std::regex_match(val, id_token_regex) ||
+                  (val == "cookie-prefix-authservice-state-cookie=deleted; "
+                                            "HttpOnly; Max-Age=0; Path=/; SameSite=Lax; "
                                             "Secure"));
     } else {
       FAIL();  // Unexpected header!
@@ -331,7 +331,7 @@ TEST_F(OidcFilterTest, RetrieveTokenMissingStateCookie) {
                 common::http::headers::PragmaDirectives::NoCache);
     } else if (iter.header().key() == common::http::headers::SetCookie) {
       ASSERT_EQ(iter.header().value(),
-                "cookie-prefix-authservice-state-cookie=deleted; HttpOnly; Path=/; "
+                "cookie-prefix-authservice-state-cookie=deleted; HttpOnly; Max-Age=0; Path=/; "
                 "SameSite=Lax; Secure");
     } else {
       FAIL();  // Unexpected header!
@@ -371,7 +371,7 @@ TEST_F(OidcFilterTest, RetrieveTokenInvalidStateCookie) {
                 common::http::headers::PragmaDirectives::NoCache);
     } else if (iter.header().key() == common::http::headers::SetCookie) {
       ASSERT_EQ(iter.header().value(),
-                "cookie-prefix-authservice-state-cookie=deleted; HttpOnly; Path=/; "
+                "cookie-prefix-authservice-state-cookie=deleted; HttpOnly; Max-Age=0; Path=/; "
                 "SameSite=Lax; Secure");
     } else {
       FAIL();  // Unexpected header!
@@ -412,7 +412,7 @@ TEST_F(OidcFilterTest, RetrieveTokenInvalidStateCookieFormat) {
                 common::http::headers::PragmaDirectives::NoCache);
     } else if (iter.header().key() == common::http::headers::SetCookie) {
       ASSERT_EQ(iter.header().value(),
-                "cookie-prefix-authservice-state-cookie=deleted; HttpOnly; Path=/; "
+                "cookie-prefix-authservice-state-cookie=deleted; HttpOnly; Max-Age=0; Path=/; "
                 "SameSite=Lax; Secure");
     } else {
       FAIL();  // Unexpected header!
@@ -448,7 +448,7 @@ TEST_F(OidcFilterTest, RetrieveTokenMissingCode) {
                 common::http::headers::PragmaDirectives::NoCache);
     } else if (iter.header().key() == common::http::headers::SetCookie) {
       ASSERT_EQ(iter.header().value(),
-                "cookie-prefix-authservice-state-cookie=deleted; HttpOnly; Path=/; "
+                "cookie-prefix-authservice-state-cookie=deleted; HttpOnly; Max-Age=0; Path=/; "
                 "SameSite=Lax; Secure");
     } else {
       FAIL();  // Unexpected header!
@@ -484,7 +484,7 @@ TEST_F(OidcFilterTest, RetrieveTokenMissingState) {
                 common::http::headers::PragmaDirectives::NoCache);
     } else if (iter.header().key() == common::http::headers::SetCookie) {
       ASSERT_EQ(iter.header().value(),
-                "cookie-prefix-authservice-state-cookie=deleted; HttpOnly; Path=/; "
+                "cookie-prefix-authservice-state-cookie=deleted; HttpOnly; Max-Age=0; Path=/; "
                 "SameSite=Lax; Secure");
     } else {
       FAIL();  // Unexpected header!
@@ -520,7 +520,7 @@ TEST_F(OidcFilterTest, RetrieveTokenUnexpectedState) {
                 common::http::headers::PragmaDirectives::NoCache);
     } else if (iter.header().key() == common::http::headers::SetCookie) {
       ASSERT_EQ(iter.header().value(),
-                "cookie-prefix-authservice-state-cookie=deleted; HttpOnly; Path=/; "
+                "cookie-prefix-authservice-state-cookie=deleted; HttpOnly; Max-Age=0; Path=/; "
                 "SameSite=Lax; Secure");
     } else {
       FAIL();  // Unexpected header!
@@ -565,7 +565,7 @@ TEST_F(OidcFilterTest, RetrieveTokenBrokenPipe) {
                 common::http::headers::PragmaDirectives::NoCache);
     } else if (iter.header().key() == common::http::headers::SetCookie) {
       ASSERT_EQ(iter.header().value(),
-                "cookie-prefix-authservice-state-cookie=deleted; HttpOnly; Path=/; "
+                "cookie-prefix-authservice-state-cookie=deleted; HttpOnly; Max-Age=0; Path=/; "
                 "SameSite=Lax; Secure");
     } else {
       FAIL();  // Unexpected header!
@@ -613,7 +613,7 @@ TEST_F(OidcFilterTest, RetrieveTokenInvalidResponse) {
                 common::http::headers::PragmaDirectives::NoCache);
     } else if (iter.header().key() == common::http::headers::SetCookie) {
       ASSERT_EQ(iter.header().value(),
-                "cookie-prefix-authservice-state-cookie=deleted; HttpOnly; Path=/; "
+                "cookie-prefix-authservice-state-cookie=deleted; HttpOnly; Max-Age=0; Path=/; "
                 "SameSite=Lax; Secure");
     } else {
       FAIL();  // Unexpected header!

--- a/test/filters/oidc/oidc_filter_test.cc
+++ b/test/filters/oidc/oidc_filter_test.cc
@@ -42,6 +42,7 @@ class OidcFilterTest : public ::testing::Test {
     config_.set_cookie_name_prefix("cookie-prefix");
     config_.mutable_id_token()->set_header("authorization");
     config_.mutable_id_token()->set_preamble("Bearer");
+    config_.set_timeout(300);
   }
 };
 

--- a/test/filters/oidc/token_response_test.cc
+++ b/test/filters/oidc/token_response_test.cc
@@ -119,13 +119,14 @@ TEST(TokenResponseParser, Parse) {
 
   auto result = parser.Parse(client_id, nonce, valid_token_response_Bearer);
   ASSERT_TRUE(result.has_value());
-  auto access_token = result->AccessToken();
-  ASSERT_EQ(access_token, std::string());
+  auto access_token1 = result->AccessToken();
+  ASSERT_FALSE(access_token1.has_value());
 
   result = parser.Parse(client_id, nonce, valid_token_response_bearer);
   ASSERT_TRUE(result.has_value());
-  access_token = result->AccessToken();
-  ASSERT_EQ(access_token, "expected");
+  auto access_token2 = result->AccessToken();
+  ASSERT_TRUE(access_token2.has_value());
+  ASSERT_EQ(*access_token2, "expected");
 }
 }  // namespace oidc
 }  // namespace filters

--- a/test/filters/oidc/token_response_test.cc
+++ b/test/filters/oidc/token_response_test.cc
@@ -21,10 +21,12 @@ const char *invalid_jwt_signing_key_ =
     "FtGJiJvOwRsIfVChDpYStTcHTCMqtvWbV6L11BWkpAGXSW4Hv43qa+GSYOD2QU68"
     "Mb59oSk2OB+BtOLpJofmbGEGgvmwyCI9MwIDAQAB";
 
+const char *client_id = "client1";
+const char *nonce = "random";
 const char *valid_token_response_Bearer =
-    R"({"token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.POstGetfAytaZS82wHcjoTyoqhMyxXiWdR7Nn7A29DNSl0EiXLdwJ6xC6AfgZWF1bOsS_TuYI3OG85AmiExREkrS6tDfTQ2B3WXlrr-wp5AokiRbz3_oB4OxG-W9KcEEbDRcZc0nH3L7LzYptiy1PtAylQGxHTWZXtGz4ht0bAecBgmpdgXMguEIcoqPJ1n3pIWk_dUZegpqx0Lka21H6XxUTxiy8OcaarA8zdnPUnV6AmNP3ecFawIFYdvJB_cm-GvpCSbr8G8y_Mllj8f4x9nBH8pQux89_6gUY618iYv7tuPWBFfEbLxtF2pZS6YC1aSfLQxeNe8djT9YjpvRZA"})";
+    R"({"token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwiYXVkIjpbImNsaWVudDEiXSwibm9uY2UiOiJyYW5kb20ifQ.NQi_VTRjZ8jv5cAp4inpuQ9STfVgCoWfONjLnZEMk8la8s99J9b6QmcKtO2tabTgvcseikVNlPuB6fZztY_fxhdrNE0dBNAl1lhz_AWBz6Yr-D82LLKk5NQ-IKDloF19Pic0Ub9pGCqNLOlmRXRVcfwwq5nISzfP6OdrjepRZ2Jd3rc2HvHYm-6GstH4xkKViABVwCDmwlAOi47bdHPByHkZOOnHSQEElr4tqO_uAQRpj36Yvt-95nPKhWaufZhcpYKk1H7ZRmylJQuG_dhlw4gN1i5iWBMk-Sj_2xyk05Bap1qkKSeHTxyqzhtDAH0LHYZdo_2hU-7YnL4JRhVVwg"})";
 const char *valid_token_response_bearer =
-    R"({"token_type":"bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.POstGetfAytaZS82wHcjoTyoqhMyxXiWdR7Nn7A29DNSl0EiXLdwJ6xC6AfgZWF1bOsS_TuYI3OG85AmiExREkrS6tDfTQ2B3WXlrr-wp5AokiRbz3_oB4OxG-W9KcEEbDRcZc0nH3L7LzYptiy1PtAylQGxHTWZXtGz4ht0bAecBgmpdgXMguEIcoqPJ1n3pIWk_dUZegpqx0Lka21H6XxUTxiy8OcaarA8zdnPUnV6AmNP3ecFawIFYdvJB_cm-GvpCSbr8G8y_Mllj8f4x9nBH8pQux89_6gUY618iYv7tuPWBFfEbLxtF2pZS6YC1aSfLQxeNe8djT9YjpvRZA"})";
+    R"({"token_type":"bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwiYXVkIjpbImNsaWVudDEiXSwibm9uY2UiOiJyYW5kb20ifQ.NQi_VTRjZ8jv5cAp4inpuQ9STfVgCoWfONjLnZEMk8la8s99J9b6QmcKtO2tabTgvcseikVNlPuB6fZztY_fxhdrNE0dBNAl1lhz_AWBz6Yr-D82LLKk5NQ-IKDloF19Pic0Ub9pGCqNLOlmRXRVcfwwq5nISzfP6OdrjepRZ2Jd3rc2HvHYm-6GstH4xkKViABVwCDmwlAOi47bdHPByHkZOOnHSQEElr4tqO_uAQRpj36Yvt-95nPKhWaufZhcpYKk1H7ZRmylJQuG_dhlw4gN1i5iWBMk-Sj_2xyk05Bap1qkKSeHTxyqzhtDAH0LHYZdo_2hU-7YnL4JRhVVwg"})";
 };  // namespace
 
 TEST(TokenResponseParser, ParseInvalidJSON) {
@@ -32,7 +34,7 @@ TEST(TokenResponseParser, ParseInvalidJSON) {
       valid_jwt_signing_key_, google::jwt_verify::Jwks::PEM);
   EXPECT_EQ(jwks->getStatus(), google::jwt_verify::Status::Ok);
   TokenResponseParserImpl parser(std::move(jwks));
-  auto result = parser.Parse("", "invalid json");
+  auto result = parser.Parse(client_id, nonce, "invalid json");
   ASSERT_FALSE(result.has_value());
 }
 
@@ -41,7 +43,7 @@ TEST(TokenResponseParser, ParseMissingTokenType) {
       valid_jwt_signing_key_, google::jwt_verify::Jwks::PEM);
   EXPECT_EQ(jwks->getStatus(), google::jwt_verify::Status::Ok);
   TokenResponseParserImpl parser(std::move(jwks));
-  auto result = parser.Parse("", R"({})");
+  auto result = parser.Parse(client_id, nonce, R"({})");
   ASSERT_FALSE(result.has_value());
 }
 
@@ -50,7 +52,7 @@ TEST(TokenResponseParser, ParseInvalidTokenType) {
       valid_jwt_signing_key_, google::jwt_verify::Jwks::PEM);
   EXPECT_EQ(jwks->getStatus(), google::jwt_verify::Status::Ok);
   TokenResponseParserImpl parser(std::move(jwks));
-  auto result = parser.Parse("", R"({"token_type":"NotBearer"})");
+  auto result = parser.Parse(client_id, nonce, R"({"token_type":"NotBearer"})");
   ASSERT_FALSE(result.has_value());
 }
 
@@ -59,7 +61,7 @@ TEST(TokenResponseParser, ParseMissingIdentityToken) {
       valid_jwt_signing_key_, google::jwt_verify::Jwks::PEM);
   EXPECT_EQ(jwks->getStatus(), google::jwt_verify::Status::Ok);
   TokenResponseParserImpl parser(std::move(jwks));
-  auto result = parser.Parse("", R"({"token_type":"Bearer"})");
+  auto result = parser.Parse(client_id, nonce, R"({"token_type":"Bearer"})");
   ASSERT_FALSE(result.has_value());
 }
 
@@ -68,7 +70,7 @@ TEST(TokenResponseParser, ParseInvalidIdentityTokenType) {
       valid_jwt_signing_key_, google::jwt_verify::Jwks::PEM);
   EXPECT_EQ(jwks->getStatus(), google::jwt_verify::Status::Ok);
   TokenResponseParserImpl parser(std::move(jwks));
-  auto result = parser.Parse("", R"({"token_type":"Bearer","id_token":1})");
+  auto result = parser.Parse(client_id, nonce, R"({"token_type":"Bearer","id_token":1})");
   ASSERT_FALSE(result.has_value());
 }
 
@@ -78,7 +80,7 @@ TEST(TokenResponseParser, ParseInvalidJwtEncoding) {
   EXPECT_EQ(jwks->getStatus(), google::jwt_verify::Status::Ok);
   TokenResponseParserImpl parser(std::move(jwks));
   auto result =
-      parser.Parse("", R"({"token_type":"Bearer","id_token":"wrong"})");
+      parser.Parse(client_id, nonce, R"({"token_type":"Bearer","id_token":"wrong"})");
   ASSERT_FALSE(result.has_value());
 }
 
@@ -87,7 +89,25 @@ TEST(TokenResponseParser, ParseInvalidJwtSignature) {
       invalid_jwt_signing_key_, google::jwt_verify::Jwks::PEM);
   EXPECT_EQ(jwks->getStatus(), google::jwt_verify::Status::Ok);
   TokenResponseParserImpl parser(std::move(jwks));
-  auto result = parser.Parse("", valid_token_response_Bearer);
+  auto result = parser.Parse(client_id, nonce, valid_token_response_Bearer);
+  ASSERT_FALSE(result.has_value());
+}
+
+TEST(TokenResponseParser, ParseMissingAudience) {
+  auto jwks = google::jwt_verify::Jwks::createFrom(
+      invalid_jwt_signing_key_, google::jwt_verify::Jwks::PEM);
+  EXPECT_EQ(jwks->getStatus(), google::jwt_verify::Status::Ok);
+  TokenResponseParserImpl parser(std::move(jwks));
+  auto result = parser.Parse("missing", nonce, valid_token_response_Bearer);
+  ASSERT_FALSE(result.has_value());
+}
+
+TEST(TokenResponseParser, ParseInvalidNonce) {
+  auto jwks = google::jwt_verify::Jwks::createFrom(
+      invalid_jwt_signing_key_, google::jwt_verify::Jwks::PEM);
+  EXPECT_EQ(jwks->getStatus(), google::jwt_verify::Status::Ok);
+  TokenResponseParserImpl parser(std::move(jwks));
+  auto result = parser.Parse(client_id, "invalid", valid_token_response_Bearer);
   ASSERT_FALSE(result.has_value());
 }
 
@@ -97,10 +117,10 @@ TEST(TokenResponseParser, Parse) {
   EXPECT_EQ(jwks->getStatus(), google::jwt_verify::Status::Ok);
   TokenResponseParserImpl parser(std::move(jwks));
 
-  auto result = parser.Parse("", valid_token_response_Bearer);
+  auto result = parser.Parse(client_id, nonce, valid_token_response_Bearer);
   ASSERT_TRUE(result.has_value());
 
-  result = parser.Parse("", valid_token_response_bearer);
+  result = parser.Parse(client_id, nonce, valid_token_response_bearer);
   ASSERT_TRUE(result.has_value());
 }
 }  // namespace oidc

--- a/test/filters/oidc/token_response_test.cc
+++ b/test/filters/oidc/token_response_test.cc
@@ -26,7 +26,9 @@ const char *nonce = "random";
 const char *valid_token_response_Bearer =
     R"({"token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwiYXVkIjpbImNsaWVudDEiXSwibm9uY2UiOiJyYW5kb20ifQ.NQi_VTRjZ8jv5cAp4inpuQ9STfVgCoWfONjLnZEMk8la8s99J9b6QmcKtO2tabTgvcseikVNlPuB6fZztY_fxhdrNE0dBNAl1lhz_AWBz6Yr-D82LLKk5NQ-IKDloF19Pic0Ub9pGCqNLOlmRXRVcfwwq5nISzfP6OdrjepRZ2Jd3rc2HvHYm-6GstH4xkKViABVwCDmwlAOi47bdHPByHkZOOnHSQEElr4tqO_uAQRpj36Yvt-95nPKhWaufZhcpYKk1H7ZRmylJQuG_dhlw4gN1i5iWBMk-Sj_2xyk05Bap1qkKSeHTxyqzhtDAH0LHYZdo_2hU-7YnL4JRhVVwg"})";
 const char *valid_token_response_bearer =
-    R"({"token_type":"bearer","access_token":"expected","id_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwiYXVkIjpbImNsaWVudDEiXSwibm9uY2UiOiJyYW5kb20ifQ.NQi_VTRjZ8jv5cAp4inpuQ9STfVgCoWfONjLnZEMk8la8s99J9b6QmcKtO2tabTgvcseikVNlPuB6fZztY_fxhdrNE0dBNAl1lhz_AWBz6Yr-D82LLKk5NQ-IKDloF19Pic0Ub9pGCqNLOlmRXRVcfwwq5nISzfP6OdrjepRZ2Jd3rc2HvHYm-6GstH4xkKViABVwCDmwlAOi47bdHPByHkZOOnHSQEElr4tqO_uAQRpj36Yvt-95nPKhWaufZhcpYKk1H7ZRmylJQuG_dhlw4gN1i5iWBMk-Sj_2xyk05Bap1qkKSeHTxyqzhtDAH0LHYZdo_2hU-7YnL4JRhVVwg"})";
+    R"({"token_type":"bearer","access_token":"expected","expires_in":3600,"id_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwiYXVkIjpbImNsaWVudDEiXSwibm9uY2UiOiJyYW5kb20ifQ.NQi_VTRjZ8jv5cAp4inpuQ9STfVgCoWfONjLnZEMk8la8s99J9b6QmcKtO2tabTgvcseikVNlPuB6fZztY_fxhdrNE0dBNAl1lhz_AWBz6Yr-D82LLKk5NQ-IKDloF19Pic0Ub9pGCqNLOlmRXRVcfwwq5nISzfP6OdrjepRZ2Jd3rc2HvHYm-6GstH4xkKViABVwCDmwlAOi47bdHPByHkZOOnHSQEElr4tqO_uAQRpj36Yvt-95nPKhWaufZhcpYKk1H7ZRmylJQuG_dhlw4gN1i5iWBMk-Sj_2xyk05Bap1qkKSeHTxyqzhtDAH0LHYZdo_2hU-7YnL4JRhVVwg"})";
+    const char *invalid_expires_in_token_response =
+        R"({"token_type":"bearer","access_token":"expected","expires_in":-1,"id_token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwiYXVkIjpbImNsaWVudDEiXSwibm9uY2UiOiJyYW5kb20ifQ.NQi_VTRjZ8jv5cAp4inpuQ9STfVgCoWfONjLnZEMk8la8s99J9b6QmcKtO2tabTgvcseikVNlPuB6fZztY_fxhdrNE0dBNAl1lhz_AWBz6Yr-D82LLKk5NQ-IKDloF19Pic0Ub9pGCqNLOlmRXRVcfwwq5nISzfP6OdrjepRZ2Jd3rc2HvHYm-6GstH4xkKViABVwCDmwlAOi47bdHPByHkZOOnHSQEElr4tqO_uAQRpj36Yvt-95nPKhWaufZhcpYKk1H7ZRmylJQuG_dhlw4gN1i5iWBMk-Sj_2xyk05Bap1qkKSeHTxyqzhtDAH0LHYZdo_2hU-7YnL4JRhVVwg"})";
 };  // namespace
 
 TEST(TokenResponseParser, ParseInvalidJSON) {
@@ -111,6 +113,16 @@ TEST(TokenResponseParser, ParseInvalidNonce) {
   ASSERT_FALSE(result.has_value());
 }
 
+TEST(TokenResponseParser, InvalidExpiresInFieldValue) {
+  auto jwks = google::jwt_verify::Jwks::createFrom(
+      valid_jwt_signing_key_, google::jwt_verify::Jwks::PEM);
+  EXPECT_EQ(jwks->getStatus(), google::jwt_verify::Status::Ok);
+  TokenResponseParserImpl parser(std::move(jwks));
+
+  auto result = parser.Parse(client_id, nonce, invalid_expires_in_token_response);
+  ASSERT_FALSE(result.has_value());
+}
+
 TEST(TokenResponseParser, Parse) {
   auto jwks = google::jwt_verify::Jwks::createFrom(
       valid_jwt_signing_key_, google::jwt_verify::Jwks::PEM);
@@ -121,12 +133,16 @@ TEST(TokenResponseParser, Parse) {
   ASSERT_TRUE(result.has_value());
   auto access_token1 = result->AccessToken();
   ASSERT_FALSE(access_token1.has_value());
+  auto expiry1 = result->Expiry();
+  ASSERT_FALSE(expiry1.has_value());
 
   result = parser.Parse(client_id, nonce, valid_token_response_bearer);
   ASSERT_TRUE(result.has_value());
   auto access_token2 = result->AccessToken();
   ASSERT_TRUE(access_token2.has_value());
-  ASSERT_EQ(*access_token2, "expected");
+      ASSERT_EQ(*access_token2, "expected");
+  auto expiry2 = result->Expiry();
+  ASSERT_TRUE(expiry2.has_value());
 }
 }  // namespace oidc
 }  // namespace filters

--- a/test/fixtures/valid-config.json
+++ b/test/fixtures/valid-config.json
@@ -43,7 +43,8 @@
         },
         "access_token": {
           "header": "x-access-token"
-        }
+        },
+        "timeout": 300
       }
     }
   ]

--- a/test/fixtures/valid-config.json
+++ b/test/fixtures/valid-config.json
@@ -24,7 +24,6 @@
           "path": "/path1",
           "port": 443
         },
-        "jwks": "some-jwks",
         "callback": {
           "scheme": "https",
           "hostname": "google4",


### PR DESCRIPTION
Fixing most of the necessary TODOs.

- Fixes validation of `nonce` and `aud` JWT fields at token acquisition time.
- Added `Max-Age` attributes to cookies.
- Removed invalid or won't-do TODOs.

fixes #33 

Any remaining TODOs can be done at a later date or will be fixed by other issues.