### PR TITLE
Enable TLS peer verification and add CA root certificates to Docker images

### DIFF
--- a/build/Dockerfile.builder
+++ b/build/Dockerfile.builder
@@ -15,6 +15,11 @@ RUN make bazel-bin/src/main/auth_server
 FROM debian:buster
 RUN groupadd -r auth-server-grp && useradd -m -g auth-server-grp auth-server-usr
 
+# Install dependencies
+RUN apt update && apt upgrade -y && apt install -y --no-install-recommends \
+    ca-certificates  \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=auth-builder \
      /src/bazel-bin/src/main/auth_server \
      /src/bazel-bin/external/boost/libboost_chrono.so.1.70.0 \

--- a/build/Dockerfile.runner
+++ b/build/Dockerfile.runner
@@ -2,6 +2,11 @@
 FROM ubuntu:19.10
 RUN groupadd -r auth-server-grp && useradd -m -g auth-server-grp auth-server-usr
 
+# Install dependencies
+RUN apt update && apt upgrade -y && apt install -y --no-install-recommends \
+    ca-certificates  \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY build_release/bazel-bin/src/main/auth_server /app/auth_server
 COPY build_release/bazel-bin/external/boost/libboost_*.so.1.70.0 /app/
 ENV LD_LIBRARY_PATH=.

--- a/src/common/http/http.cc
+++ b/src/common/http/http.cc
@@ -298,8 +298,7 @@ response_t http_impl::Post(
     // The io_context is required for all I/O
     net::io_context ioc;
     ssl::context ctx(ssl::context::tlsv12_client);
-    // TODO: verify_peer should be used but is not currently working.
-    ctx.set_verify_mode(ssl::verify_none);
+    ctx.set_verify_mode(ssl::verify_peer);
     ctx.set_default_verify_paths();
 
     tcp::resolver resolver(ioc);
@@ -361,8 +360,7 @@ response_t http_impl::Post(
     int version = 11;
 
     ssl::context ctx(ssl::context::tlsv12_client);
-    // TODO: verify_peer should be used but is not currently working.
-    ctx.set_verify_mode(ssl::verify_none);
+    ctx.set_verify_mode(ssl::verify_peer);
     ctx.set_default_verify_paths();
 
     tcp::resolver resolver(ioc);


### PR DESCRIPTION
Enables TLS peer verification for connection to upstream IDP services, to ensure the connections are secure. Also adds standard ca_certificates package to the Docker images which is required for verification of the certificate chains.