### PR TITLE
Envoy to return 400 status instead of dropping request

### DIFF
--- a/src/filters/oidc/oidc_filter.cc
+++ b/src/filters/oidc/oidc_filter.cc
@@ -486,7 +486,9 @@ google::rpc::Code OidcFilter::RetrieveToken(
   auto authorization_state = session_store_->GetAuthorizationState(session_id);
   if (!authorization_state) {
     spdlog::info("{}: Missing state, nonce, and original url requested by the user. Cannot redirect.", __func__);
-    return google::rpc::Code::UNAVAILABLE;
+    response->mutable_denied_response()->mutable_status()->set_code(envoy::type::StatusCode::BadRequest);
+    response->mutable_denied_response()->set_body("Oops, your session has expired. Please try again.");
+    return google::rpc::Code::UNAUTHENTICATED;
   }
 
   // Compare state from request and session


### PR DESCRIPTION
Cause Envoy to return 400 status code when accessing callback url
when session is expired. This may happen if the user is redirected to
the IdP and takes more time to log in than the session timeout

Fixes https://github.com/istio-ecosystem/authservice/issues/91

Signed-off-by: Tyler Schultz <tschultz@pivotal.io>