### PR TITLE
Upgrade ssl context to sslv3

### DIFF
--- a/src/common/http/http.cc
+++ b/src/common/http/http.cc
@@ -363,7 +363,7 @@ response_t HttpImpl::Post(absl::string_view uri,
   try {
     int version = 11;
 
-    ssl::context ctx(ssl::context::tlsv12_client);
+    ssl::context ctx(ssl::context::sslv3_client);
     ctx.set_verify_mode(ssl::verify_peer);
     ctx.set_default_verify_paths();
 


### PR DESCRIPTION
tlsv12 causes issues with validating certificates on some idP servers with valid ssl certs, upgrading to sslv3 fixes these issues.