### PR TITLE
Update Istio download script to use 1.4.10

### DIFF
--- a/bookinfo-example/scripts/download-istio-1.4.sh
+++ b/bookinfo-example/scripts/download-istio-1.4.sh
@@ -5,5 +5,5 @@ set -eux
 script_dir=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 cd ${script_dir}/..
 
-ISTIO_VERSION=1.4.0
+ISTIO_VERSION=1.4.10
 curl -L https://git.io/getLatestIstio | ISTIO_VERSION=${ISTIO_VERSION} sh -

--- a/bookinfo-example/scripts/install-istio.sh
+++ b/bookinfo-example/scripts/install-istio.sh
@@ -3,7 +3,7 @@
 set -eux
 
 script_dir=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
-cd ${script_dir}/../istio-1.4.0
+cd ${script_dir}/../istio-1.4.10
 
 # Follow quick setup instructions for Istio
 for i in install/kubernetes/helm/istio-init/files/crd*yaml; do


### PR DESCRIPTION
1.4.0 was causing Envoy crashes following the bookinfo example. Using 1.4.10 prevented the Envoy crashes.