### PR TITLE
Fixes envoy filter to work with istio 1.7.4

### DIFF
--- a/bookinfo-example/config/productpage-external-authz-envoyfilter-sidecar.yaml
+++ b/bookinfo-example/config/productpage-external-authz-envoyfilter-sidecar.yaml
@@ -17,43 +17,45 @@ spec:
     labels:
       app: productpage # target the app to which you want to apply the filter
   configPatches:
-  - applyTo: HTTP_FILTER
-    match:
-      context: SIDECAR_INBOUND
-      listener:
-        filterChain:
-          filter:
-            name: "envoy.http_connection_manager"
-            subFilter:
-              name: "envoy.filters.http.jwt_authn"
-    patch:
-      operation: INSERT_BEFORE
-      value:
-       name: envoy.ext_authz
-       config:
-         stat_prefix: ext_authz
-         grpc_service:
-           envoy_grpc:
-             cluster_name: ext_authz
-           timeout: 10s # Timeout for the entire request (including authcode for token exchange with the IDP)
-  - applyTo: CLUSTER
-    match:
-      context: ANY
-      cluster: {} # this line is required starting in istio 1.4.0
-    patch:
-      operation: ADD
-      value:
-        name: ext_authz
-        connect_timeout: 5s # This timeout controls the initial TCP handshake timeout - not the timeout for the entire request
-        type: LOGICAL_DNS
-        lb_policy: ROUND_ROBIN
-        http2_protocol_options: {}
-        load_assignment:
-          cluster_name: ext_authz
-          endpoints:
-            - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: 127.0.0.1
-                        port_value: 10003
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.filters.http.jwt_authn"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.ext_authz
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+            grpc_service:
+              envoy_grpc:
+                cluster_name: ext-authz
+              # Default is 200ms; override if your server needs e.g. warmup time.
+              timeout: 0.5s
+    - applyTo: CLUSTER
+      match:
+        context: ANY
+        cluster: {} # this line is required starting in istio 1.4.0
+      patch:
+        operation: ADD
+        value:
+          name: ext-authz
+          type: STATIC
+          http2_protocol_options: {}
+          load_assignment:
+            cluster_name: ext-authz
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: 127.0.0.1
+                          port_value: 10003
+          # This timeout controls the initial TCP handshake timeout - not the timeout for the
+          # entire request.
+          connect_timeout: 0.25s


### PR DESCRIPTION
Fixes issue #122. Seems like the typed config makes the filter work again with istio 1.7.x. I've used the example here: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_authz_filter