### PR TITLE
Add option to skip TLS verification in OIDC filter

### DIFF
--- a/config/oidc/config.proto
+++ b/config/oidc/config.proto
@@ -171,4 +171,9 @@ message OIDCConfig {
     // When specified, the Authservice will use the configured Redis server to store session data.
     // Optional.
     RedisConfig redis_session_store_config = 16;
+
+    // When specified, the Authservice will not validate OIDC Identity Provider certificate.
+    // Default is false.
+    // Optional.
+    bool skip_openid_provider_tls_verify = 17;
 }

--- a/src/common/http/http.cc
+++ b/src/common/http/http.cc
@@ -358,13 +358,19 @@ response_t HttpImpl::Post(absl::string_view uri,
                           absl::string_view ca_cert,
                           absl::string_view proxy_uri,
                           boost::asio::io_context &ioc,
-                          boost::asio::yield_context yield) const {
+                          boost::asio::yield_context yield,
+                          bool skip_tls) const {
   spdlog::trace("{}", __func__);
   try {
     int version = 11;
 
     ssl::context ctx(ssl::context::tlsv12_client);
-    ctx.set_verify_mode(ssl::verify_peer);
+    if (skip_tls) {
+      ctx.set_verify_mode(ssl::verify_none);
+    } else {
+      ctx.set_verify_mode(ssl::verify_peer);
+    }
+
     ctx.set_default_verify_paths();
 
     if (!ca_cert.empty()) {

--- a/src/common/http/http.h
+++ b/src/common/http/http.h
@@ -185,6 +185,7 @@ public:
    * @param headers the http headers
    * @param body the http request body
    * @param ca_cert the ca cert to be trusted in the http call
+   * @param skip_tls skips tls verification
    * @return http response.
    */
   virtual response_t Post(absl::string_view uri,
@@ -193,7 +194,8 @@ public:
                           absl::string_view ca_cert,
                           absl::string_view proxy_uri,
                           boost::asio::io_context &ioc,
-                          boost::asio::yield_context yield) const = 0;
+                          boost::asio::yield_context yield,
+                          bool skip_tls) const = 0;
 };
 
 /**
@@ -207,7 +209,8 @@ public:
                   absl::string_view ca_cert,
                   absl::string_view proxy_uri,
                   boost::asio::io_context &ioc,
-                  boost::asio::yield_context yield) const override;
+                  boost::asio::yield_context yield,
+                  bool skip_tls) const override;
 };
 
 }  // namespace http

--- a/src/filters/oidc/oidc_filter.cc
+++ b/src/filters/oidc/oidc_filter.cc
@@ -484,7 +484,7 @@ std::shared_ptr<TokenResponse> OidcFilter::RefreshToken(
   spdlog::info("{}: POSTing to refresh access token", __func__);
   auto retrieved_token_response = http_ptr_->Post(
       idp_config_.token_uri(), headers, common::http::Http::EncodeFormData(params),
-      idp_config_.trusted_certificate_authority(), idp_config_.proxy_uri(), ioc, yield);
+      idp_config_.trusted_certificate_authority(), idp_config_.proxy_uri(), ioc, yield, idp_config_.skip_openid_provider_tls_verify());
 
   if (retrieved_token_response == nullptr) {
     spdlog::warn("{}: Received null pointer as response from identity provider.", __func__);
@@ -563,7 +563,7 @@ google::rpc::Code OidcFilter::RetrieveToken(
 
   auto retrieve_token_response = http_ptr_->Post(
       idp_config_.token_uri(), headers, common::http::Http::EncodeFormData(params),
-      idp_config_.trusted_certificate_authority(), idp_config_.proxy_uri(), ioc, yield);
+      idp_config_.trusted_certificate_authority(), idp_config_.proxy_uri(), ioc, yield, idp_config_.skip_openid_provider_tls_verify());
   if (retrieve_token_response == nullptr) {
     spdlog::info("{}: HTTP error encountered: {}", __func__,
                  "IdP connection error");

--- a/test/common/http/mocks.h
+++ b/test/common/http/mocks.h
@@ -9,14 +9,15 @@ namespace common {
 namespace http {
 class HttpMock : public Http {
 public:
-  MOCK_CONST_METHOD7(Post, response_t(
+  MOCK_CONST_METHOD8(Post, response_t(
       absl::string_view uri,
       const std::map<absl::string_view, absl::string_view> &headers,
       absl::string_view body,
       absl::string_view ca_cert,
       absl::string_view proxy_uri,
       boost::asio::io_context &ioc,
-      boost::asio::yield_context yield));
+      boost::asio::yield_context yield,
+      bool skip_tls));
 };
 }  // namespace http
 }  // namespace common

--- a/test/filters/oidc/oidc_filter_test.cc
+++ b/test/filters/oidc/oidc_filter_test.cc
@@ -395,7 +395,7 @@ TEST_F(OidcFilterTest,
   auto *pMessage = new beast::http::response<beast::http::string_body>();
   auto raw_http_token_response_from_idp = common::http::response_t(pMessage);
   raw_http_token_response_from_idp->result(beast::http::status::ok);
-  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _)).WillOnce(
+  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _, _)).WillOnce(
       Return(ByMove(std::move(raw_http_token_response_from_idp))));
 
   auto jwt_status = test_id_token_jwt_.parseFromString(test_id_token_jwt_string_);
@@ -440,7 +440,7 @@ TEST_F(OidcFilterTest, ReturnsUnauthorized_WhenSessionStoreThrowsErrorDuringRefr
   auto *pMessage = new beast::http::response<beast::http::string_body>();
   auto raw_http_token_response_from_idp = common::http::response_t(pMessage);
   raw_http_token_response_from_idp->result(beast::http::status::ok);
-  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _)).WillOnce(
+  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _, _)).WillOnce(
       Return(ByMove(std::move(raw_http_token_response_from_idp))));
 
   auto jwt_status = test_id_token_jwt_.parseFromString(test_id_token_jwt_string_);
@@ -520,7 +520,7 @@ TEST_F(OidcFilterTest, Process_RedirectsUsersToAuthenticate_WhenFailingToParseTh
   auto *pMessage = new beast::http::response<beast::http::string_body>();
   auto raw_http_token_response_from_idp = common::http::response_t(pMessage);
   raw_http_token_response_from_idp->result(beast::http::status::ok);
-  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _)).WillOnce(
+  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _, _)).WillOnce(
       Return(ByMove(std::move(raw_http_token_response_from_idp))));
 
   EXPECT_CALL(*parser_mock_, ParseRefreshTokenResponse(_, _)).WillOnce(::testing::Return(nullptr));
@@ -562,7 +562,7 @@ TEST_F(OidcFilterTest, Process_RedirectsUsersToAuthenticate_WhenFailingToEstabli
   SetExpiredAccessTokenResponseInSessionStore();
 
   auto mocked_http = new common::http::HttpMock();
-  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _)).WillOnce(
+  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _, _)).WillOnce(
       Return(ByMove(nullptr)));
 
   auto old_session_id = std::string("session123");
@@ -604,7 +604,7 @@ TEST_F(OidcFilterTest, Process_RedirectsUsersToAuthenticate_WhenIDPReturnsUnsucc
   auto *pMessage = new beast::http::response<beast::http::string_body>();
   auto raw_http_token_response_from_idp = common::http::response_t(pMessage);
   raw_http_token_response_from_idp->result(beast::http::status::bad_request);
-  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _)).WillOnce(
+  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _, _)).WillOnce(
       Return(ByMove(std::move(raw_http_token_response_from_idp))));
 
   // we want the code to return before attempting to parse the bad response
@@ -933,7 +933,7 @@ google::rpc::Code OidcFilterTest::MakeRequestWhichWillCauseTokenRetrieval(absl::
   auto mocked_http = new common::http::HttpMock();
   auto raw_http = common::http::response_t(new beast::http::response<beast::http::string_body>());
   raw_http->result(beast::http::status::ok);
-  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _))
+  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _, _))
       .WillOnce(Return(ByMove(std::move(raw_http))));
   OidcFilter filter(common::http::ptr_t(mocked_http), config_, parser_mock_, session_string_generator_mock_,
                     session_store_mock_);
@@ -962,7 +962,7 @@ TEST_F(OidcFilterTest, RetrieveToken_ReturnsError_WhenTokenResponseIsMissingAcce
   auto raw_http = common::http::response_t(
       new beast::http::response<beast::http::string_body>());
   raw_http->result(beast::http::status::ok);
-  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _))
+  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _, _))
       .WillOnce(Return(ByMove(std::move(raw_http))));
   ASSERT_FALSE(session_store_->GetTokenResponse(session_id));
   OidcFilter filter(common::http::ptr_t(mocked_http), config_, parser_mock_, session_string_generator_mock_,
@@ -1075,7 +1075,7 @@ TEST_F(OidcFilterTest, RetrieveToken_ReturnsError_WhenBrokenPipe) {
 
   auto *mocked_http = new common::http::HttpMock();
   auto raw_http = common::http::response_t();
-  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _))
+  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _, _))
       .WillOnce(Return(ByMove(std::move(raw_http))));
   OidcFilter filter(common::http::ptr_t(mocked_http), config_, parser_mock_, session_string_generator_mock_,
                     session_store_);
@@ -1110,7 +1110,7 @@ TEST_F(OidcFilterTest, RetrieveToken_ReturnsError_WhenInvalidResponse) {
   auto *mocked_http = new common::http::HttpMock();
   auto raw_http = common::http::response_t(
       (new beast::http::response<beast::http::string_body>()));
-  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _))
+  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _, _))
       .WillOnce(Return(ByMove(std::move(raw_http))));
   OidcFilter filter(common::http::ptr_t(mocked_http), config_, parser_mock_, session_string_generator_mock_,
                     session_store_);
@@ -1184,7 +1184,7 @@ void OidcFilterTest::AssertRetrieveToken(config::oidc::OIDCConfig &oidcConfig, s
   auto raw_http = common::http::response_t(
       new beast::http::response<beast::http::string_body>());
   raw_http->result(beast::http::status::ok);
-  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _))
+  EXPECT_CALL(*mocked_http, Post(Eq(token_uri), _, _, Eq("some-ca"), Eq("http://some-proxy-uri.com"), _, _, _))
       .WillOnce(Return(ByMove(std::move(raw_http))));
   OidcFilter filter(common::http::ptr_t(mocked_http), oidcConfig, parser_mock_, session_string_generator_mock_,
                     session_store_);


### PR DESCRIPTION
In case of an internal OIDC Provider behind envoy, the verification of the certificate may not needed. 
