### PR TITLE
Add global filter chain configuration API part 1

### DIFF
--- a/config/config.proto
+++ b/config/config.proto
@@ -53,6 +53,11 @@ message FilterChain {
     // Optional.
     Match match = 2;
 
+    // Global configuration of this filter chain. It will be dismissed when OIDC config set per filter.
+    // Configuration items will be shared with all filters.
+    // Optional.
+    oidc.OIDCConfig global_config = 4;
+
     // The configuration of one of more filters in the filter chain. When the filter chain
     // matches an incoming request, then this list of filters will be applied to the request
     // in the order that they are declared.

--- a/config/config.proto
+++ b/config/config.proto
@@ -53,7 +53,7 @@ message FilterChain {
     // Optional.
     Match match = 2;
 
-    // Global configuration of this filter chain. It will be dismissed when OIDC config set per filter.
+    // Global configuration of this filter chain. It will be ignored when OIDC config set per filter.
     // Configuration items will be shared with all filters.
     // Optional.
     oidc.OIDCConfig global_config = 4;

--- a/config/config.proto
+++ b/config/config.proto
@@ -38,6 +38,11 @@ message Filter {
 
         // An OpenID Connect filter configuration.
         oidc.OIDCConfig oidc = 1;
+
+        // This value will be used when `default_oidc_config` exists. 
+        // It will override values of them. If that doesn't exists, 
+        // this configuration will be rejected.
+        oidc.OIDCConfig oidc_override = 2;
     }
 }
 
@@ -52,11 +57,6 @@ message FilterChain {
     // If not defined, the filter chain will match every request.
     // Optional.
     Match match = 2;
-
-    // Global configuration of this filter chain. It will be ignored when OIDC config set per filter.
-    // Configuration items will be shared with all filters.
-    // Optional.
-    oidc.OIDCConfig global_config = 4;
 
     // The configuration of one of more filters in the filter chain. When the filter chain
     // matches an incoming request, then this list of filters will be applied to the request
@@ -111,6 +111,11 @@ message Config {
     // intercept requests made to those paths to perform the appropriate login/logout behavior.
     // Optional. Leave this empty to always trigger authentication for all paths.
     repeated TriggerRule trigger_rules = 9;
+
+    // Global configuration of OIDC. This value will be applied to all filter definition 
+    // when it defined as `oidc_override`.
+    // Optional.
+    oidc.OIDCConfig default_oidc_config = 10;
 }
 
 // Trigger rule to match against a request. The trigger rule is satisfied if


### PR DESCRIPTION
The initial part of adding global filter chain configuration. #132

It allows for users to set global configuration that will be applied to all filters in the same filter chain.