### PR TITLE
Update Dockerfile.

### DIFF
--- a/build/Dockerfile.runner
+++ b/build/Dockerfile.runner
@@ -1,5 +1,5 @@
 # Creates final auth-server container image from an already built binary
-FROM ubuntu:19.10
+FROM ubuntu:20.10
 RUN groupadd -r auth-server-grp && useradd -m -g auth-server-grp auth-server-usr
 
 # Install dependencies
@@ -14,4 +14,5 @@ RUN chgrp auth-server-grp /app/* && chown auth-server-usr /app/* && chmod u+x /a
 
 USER auth-server-usr
 WORKDIR /app
-ENTRYPOINT ["GRPC_VERBOSITY=debug", "/app/auth_server"]
+ENV GRPC_VERBOSITY=debug
+ENTRYPOINT ["/app/auth_server"]


### PR DESCRIPTION
Two fixes in one commit:

1.  update `FROM` to Ubuntu 20.10 due to an apt-get error:
```
E: The repository 'http://security.ubuntu.com/ubuntu eoan-security Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu eoan Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu eoan-updates Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu eoan-backports Release' does not have a Release file.
The command '/bin/sh -c apt update && apt upgrade -y && apt install -y --no-install-recommends     ca-certificates      && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
```

2. Move the environment variable from `ENTRYPOINT` to `ENV` to fix this runtime error:
```
docker: Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"GRPC_VERBOSITY=debug\": executable file not found in $PATH": unknown.
```