### PR TITLE
fix to treat IDToken header as case-insensitive

### DIFF
--- a/src/config/BUILD
+++ b/src/config/BUILD
@@ -13,5 +13,6 @@ xx_library(
         "//src/common/http:http",
         "@com_github_abseil-cpp//absl/strings:strings",
         "@com_github_gabime_spdlog//:spdlog",
+        "@envoy//source/common/http:header_map_lib",
     ],
 )

--- a/test/config/getconfig_test.cc
+++ b/test/config/getconfig_test.cc
@@ -378,7 +378,7 @@ TEST_F(GetConfigTest, OverrideOIDCConfigSuccess) {
               "jwks": "default_jwk",
               "id_token": {
                 "preamble": "Bearer",
-                "header": "authorization"
+                "header": "Authorization"
               },
               "client_id": "test-istio",
               "client_secret": "xxxxx-yyyyy-zzzzz"


### PR DESCRIPTION
Close #141 

In this PR, we fix the previous behavior which treat specified ID token header as case-sensitive. It is not required behavior and if we set `Authorization` as this. We will skip token check because ext_authz passes lower cased HTTP header value.