### PR TITLE
Update authservice using external authz.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SRCS=$(shell find . -name '*.cc')
 HDRS=$(shell find . -name '*.h')
 TARGET:=//src/main:auth_server
 BAZEL_FLAGS:= --verbose_failures
+IMAGE?=authservice:$(USER)
 
 all: build test docs
 
@@ -18,7 +19,7 @@ compose:
 	docker-compose up --build
 
 docker: build
-	rm -rf build_release && mkdir -p build_release && cp -r bazel-bin/ build_release && docker build -f build/Dockerfile.runner -t authservice:$(USER) .
+	rm -rf build_release && mkdir -p build_release && cp -r bazel-bin/ build_release && docker build . -f build/Dockerfile.runner -t $(IMAGE) && docker push $(IMAGE)
 
 docker-from-scratch:
 	docker build -f build/Dockerfile.builder -t authservice:$(USER) .

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ compose:
 	docker-compose up --build
 
 docker: build
-	rm -rf build_release && mkdir -p build_release && cp -r bazel-bin/ build_release && docker build . -f build/Dockerfile.runner -t $(IMAGE) && docker push $(IMAGE)
+	rm -rf build_release && mkdir -p build_release && cp -r bazel-bin/ build_release && docker build . -f build/Dockerfile.runner -t $(IMAGE)
 
 docker-from-scratch:
 	docker build -f build/Dockerfile.builder -t authservice:$(USER) .

--- a/bookinfo-example/README.md
+++ b/bookinfo-example/README.md
@@ -14,7 +14,8 @@ Things needed before starting:
 provider will be needed to configure Authservice.
  
 ### Pre-requisites:
-1. Download Istio 1.3 or greater. For example:
+
+1. Download Istio 1.9 or greater. For example:
 
    [`scripts/download-istio-1.4.sh`](scripts/download-istio-1.4.sh)
 
@@ -27,12 +28,24 @@ provider will be needed to configure Authservice.
 
    [`scripts/generate-self-signed-certs-for-ingress-gateway.sh`](scripts/generate-self-signed-certs-for-ingress-gateway.sh)
 
+1. Configure the Istio mesh config with an [external authorization provider](https://istio.io/latest/docs/tasks/security/authorization/authz-custom/) as `sample-ext-authz-grpc`.
+
+   ```yaml
+   data:
+   mesh: |-
+      extensionProviders:
+      - name: "sample-ext-authz-grpc"
+         envoyExtAuthzGrpc:
+         service: ext.authz.local
+         port: "10003"
+   ```
 
 ## Deploy Bookinfo Using the Authservice for Token Acquisition (Sidecar integration)
 
 The goal of these steps is the protect the `productpage` service with OIDC authentication provided by the mesh.
 
 These steps demonstrate how to:
+
 1. Configure the Authservice to provide token acquisition for end-users of the `productpage` service
 1. Deploy the Authservice along with the Bookinfo sample app, in the same pod as the `productpage` service
 1. Configure Istio authentication for the `productpage` service, using standard Istio features
@@ -41,28 +54,31 @@ These steps demonstrate how to:
 To keep things simple, we deploy everything into the default namespace and we don't enable authentication for the
 other services of the Bookinfo app aside from `productpage`.
 
+1. Prepare your OIDC provider configuration. For our example, we are using Google as IdP.
+Follow [instructions](https://developers.google.com/identity/protocols/oauth2/openid-connect) to create one
+if needed.
+
 1. Setup a `ConfigMap` for Authservice. Fill in [`config/authservice-configmap-template-for-authn.yaml`](config/authservice-configmap-template-for-authn.yaml)
-   to include the OIDC provider's configurations. Currently, only the `oidc` filter can be configured in the `ConfigMap`. See [here](../docs/README.md)
-   for the description of each field. Once the values have been substituted, apply the `ConfigMap`.
+   to include the OIDC provider's configurations. Currently, only the `oidc` filter can be configured in the 
+   `ConfigMap`. See [here](../docs/README.md) for the description of each field. Once the values
+   have been substituted, apply the `ConfigMap`.
    
    `kubectl apply -f config/authservice-configmap-template-for-authn.yaml`
     ### <a name="authservice-image"></a> 
-1. The Github Package Registry does not work seamlessly with k8s until [issue #870](https://github.com/kubernetes-sigs/kind/issues/870)
-   is fixed and released. As a workaround, manually `docker pull` the latest authservice image from
-   [https://github.com/istio-ecosystem/authservice/packages](https://github.com/istio-ecosystem/authservice/packages)
-   and push it to an accessible image registry (e.g. Docker Hub).
-   See the ["Using the authservice docker image" section in the README.md](https://github.com/istio-ecosystem/authservice/blob/master/README.md#using-the-authservice-docker-image)
-   for more information.
 
-1. Edit [`config/bookinfo-with-authservice-template.yaml`](config/bookinfo-with-authservice-template.yaml)
-   and replace the authservice image name with the reference to the image in the registry from the step above.
-   Then apply the file to deploy Bookinfo and Authservice.
+1. Apply the authservice deployment.
 
     `kubectl apply -f config/bookinfo-with-authservice-template.yaml`
     
     Wait for the new pods to be in `Running` state.
     
     Note that the Authservice will be deployed in the same Pod as `productpage`.
+
+1. Configure the product page to enable authservice via a `CUSTOM` action authorization policy.
+
+   ```shell
+   kubectl apply -f ./config/ext-authz-productpage.yaml
+   ```
 
 1. If the `callback` or `logout` paths in [`config/authservice-configmap-template-for-authn.yaml`](config/authservice-configmap-template-for-authn.yaml)
    were edited in a previous step, then edit those same paths in [`config/bookinfo-gateway.yaml`](config/bookinfo-gateway.yaml).
@@ -82,28 +98,18 @@ other services of the Bookinfo app aside from `productpage`.
    and without activating the Authservice, so the `productpage` UI should show in the browser without being
    asked to authenticate.
 
-1. Edit the `issuer` and `jwksUri` settings in [`config/bookinfo-authn-policy-template.yaml`](config/bookinfo-authn-policy-template.yaml). 
-   Apply the Authentication Policy for the Bookinfo application:
-
-    `kubectl apply -f config/bookinfo-authn-policy-template.yaml`
-    
-   Wait about a minute for the policy to take effect, then visit the Bookinfo `productpage` UI with a browser again.
-   The page should not be accessible by an unauthenticated user, giving a 401 `Origin authentication failed.` error message.
-
-   The UI is now protected by Istio's authentication JWT checking feature, but nothing is helping the user authenticate,
-   acquire tokens, save those tokens, or transmit those tokens to the `productpage` service. Authservice to the rescue!
-
-1. We're ready to put the Authservice into the data path for `productpage` by adding
-   the [External Authorization filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_authz_filter#config-http-filters-ext-authz)
-   using an [Istio EnvoyFilter](https://istio.io/docs/reference/config/networking/v1alpha3/envoy-filter/). 
-   This example shows how to insert the External Authorization filter in the sidecar of the `productpage` app.
-   The filter is inserted before the [Istio Authentication Policy](https://istio.io/docs/tasks/security/authn-policy/),
-   which was added in the previous step.
+1. We're ready to put the Authservice into the data path for `productpage` by 
+   using an [Istio ExternalAuthorization](https://istio.io/latest/docs/tasks/security/authorization/authz-custom/). 
 
     `kubectl apply -f config/productpage-external-authz-envoyfilter-sidecar.yaml`
 
-   Wait about a minute for the policy to take effect, then visit the Bookinfo `productpage` UI with a browser again.
-   This time the browser should redirect to the OIDC provider's login page. Upon login, the authenticated user should
+1. Access the application at the `localhost:8443` via port forwarding, https://localhost:8443/productpage.
+
+   ```shell
+   kubectl port-forward service/istio-ingressgateway 8443:443 -n istio-system
+   ```
+
+   The browser should redirect to the OIDC provider's login page. Upon login, the authenticated user should
    be redirected back and gain access to the `productpage`.
    
    This works because the Authservice is involved in every request to the `productpage` service.
@@ -295,3 +301,14 @@ The steps of using Authservice at the Ingress-gateway are roughly the same as th
 1. The path part of the configured `callback_uri`, and if configured, the `logout.path`, must be paths that are routable to the app by the ingress gateway's `VirtualService`, or else the Authservice at the gateway will not receieve those requests and will not be able to process them. This is a perhaps counter-intuitive since the Authservice container is no longer running in the app's pod, so it may not feel like this is needed, but it is required.
 
 Better user experience and more sample configs will be added in the future.
+
+## FAQ
+
+Where I can find the authservice images?
+
+1. The Github Package Registry does not work seamlessly with k8s until [issue #870](https://github.com/kubernetes-sigs/kind/issues/870)
+   is fixed and released. As a workaround, manually `docker pull` the latest authservice image from
+   [https://github.com/istio-ecosystem/authservice/packages](https://github.com/istio-ecosystem/authservice/packages)
+   and push it to an accessible image registry (e.g. Docker Hub).
+   See the ["Using the authservice docker image" section in the README.md](https://github.com/istio-ecosystem/authservice/blob/master/README.md#using-the-authservice-docker-image)
+   for more information.

--- a/bookinfo-example/config/authservice-configmap-template-for-authn.yaml
+++ b/bookinfo-example/config/authservice-configmap-template-for-authn.yaml
@@ -24,12 +24,12 @@ data:
           {
             "oidc":
               {
-                "authorization_uri": "https://demo.example.change.me/oauth/authorize/change/me",
-                "token_uri": "https://demo.example.change.me/oauth/token/change/me",
-                "callback_uri": "https://INGRESS_HOST_CHANGE_ME/productpage/oauth/callback",
-                "jwks": "{\"keys\":[{\"kty\":\"RSA\",\"e\":\"AQAB\",\"use\":\"sig\",\"kid\":\"sha2-2017-01-20-key\",\"alg\":\"RS256\",\"value\":\"-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyH6kYCP29faDAUPKtei3\nV/Zh8eCHyHRDHrD0iosvgHuaakK1AFHjD19ojuPiTQm8r8nEeQtHb6mDi1LvZ03e\nEWxpvWwFfFVtCyBqWr5wn6IkY+ZFXfERLn2NCn6sMVxcFV12sUtuqD+jrW8MnTG7\nhofQqxmVVKKsZiXCvUSzfiKxDgoiRuD3MJSoZ0nQTHVmYxlFHuhTEETuTqSPmOXd\n/xJBVRi5WYCjt1aKRRZEz04zVEBVhVkr2H84qcVJHcfXFu4JM6dg0nmTjgd5cZUN\ncwA1KhK2/Qru9N0xlk9FGD2cvrVCCPWFPvZ1W7U7PBWOSBBH6GergA+dk2vQr7Ho\nlQIDAQAB\n-----END PUBLIC KEY-----\",\"n\":\"AMh-pGAj9vX2gwFDyrXot1f2YfHgh8h0Qx6w9IqLL4B7mmpCtQBR4w9faI7j4k0JvK_JxHkLR2-pg4tS72dN3hFsab1sBXxVbQsgalq-cJ-iJGPmRV3xES59jQp-rDFcXBVddrFLbqg_o61vDJ0xu4aH0KsZlVSirGYlwr1Es34isQ4KIkbg9zCUqGdJ0Ex1ZmMZRR7oUxBE7k6kj5jl3f8SQVUYuVmAo7dWikUWRM9OM1RAVYVZK9h_OKnFSR3H1xbuCTOnYNJ5k44HeXGVDXMANSoStv0K7vTdMZZPRRg9nL61Qgj1hT72dVu1OzwVjkgQR-hnq4APnZNr0K-x6JU\"}]}",
-                "client_id": "xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx_CHANGE_ME",
-                "client_secret": "xxxxx-xxxx-xxx-xxx-xxx_CHANGE_ME",
+                "authorization_uri": "https://accounts.google.com/o/oauth2/v2/auth",
+                "token_uri": "https://oauth2.googleapis.com/token",
+                "callback_uri": "https://localhost:8443/productpage/oauth/callback",
+                "jwks": "{   \"keys\": [     {       \"use\": \"sig\",       \"alg\": \"RS256\",       \"n\": \"7qnlkR2Ysvik__jqELu5__2Ib4_Pix6NEmEYKY80NyIGBhUQ0QDtijFypOk3cN3aRgb1f3741vQu7PQGMr79J8jM4-sA1A6UQNmfjl-thB5JpdfQrS1n3EpsrPMUvf5w-uBMQnxmiM3hrHgjA107-UxLF_xBG8Vp_EXmZI7y6IfUwTHrNotSpLLBSNH77C8ncFcm9ADsdl-Bav2CjOaef6CpGISCscx2T4LZS6DIafU1M_xYcx3aLET9TojymjZJi2hfZDyF9x_qssrlnxqfgrI71warY8HiXsiZzOTNB6s81Fu9AaxV7YckfLHyvXwOX8lQN53c2IiAuk-T7nf69w\",       \"e\": \"AQAB\",       \"kty\": \"RSA\",       \"kid\": \"0fcc014f22934e47480daf107a340c22bd262b6c\"     },     {       \"alg\": \"RS256\",       \"e\": \"AQAB\",       \"kid\": \"462949174f1eedf4f9f9434877be483b324140f5\",       \"kty\": \"RSA\",       \"n\": \"2BHFUUq8NqZ3pxxi_RJcSIMG5nJoZQ8Nbvf-lW5o7hJ9CmLA4SeUmDL2IVK6CSuskTPj_ohAp_gtOg3PCJvn33grPoJQu38MoMB8kDqA4U-u3A86GGEjWtk6LPo7dEkojZNQkzhZCnEMTuRMtBZXsLWNGJpY3UADA3rxnHnBP1wrSt27iXIE0C6-1N5z00R13r3L0aWC0MuAUgjI2H4dGMr8B3niJ-NjOVPCwG7xSWsCwsSitAuhPGHaDtenB23ZsFJjbuTuiguoSJ9A1qo9kzBOg32xda4derbWasu7Tk8p53PFxXDJGR_h7dM-nsJHl7lAUDqL8zOrf9XXlPTjwQ\",       \"use\": \"sig\"     }   ] }",
+                "client_id": "YOUR_OIDC_CLIENT_ID",
+                "client_secret": "YOUR_OIDC_CLIENT_SECRET",
                 "scopes": [],
                 "cookie_name_prefix": "productpage",
                 "id_token": {
@@ -38,7 +38,7 @@ data:
                 },
                 "logout": {
                   "path": "/authservice_logout",
-                  "redirect_uri": "https://<demo.example.change.me>/some/logout/path"
+                  "redirect_uri": "https://localhost:8443/some/logout/path"
                 }
               }
             }

--- a/bookinfo-example/config/bookinfo-gateway.yaml
+++ b/bookinfo-example/config/bookinfo-gateway.yaml
@@ -19,9 +19,7 @@ spec:
         - "*"
       tls:
         mode: SIMPLE
-        serverCertificate: /etc/istio/ingressgateway-certs/tls.crt # pre-req: generate a k8s secret containing these cert files
-        privateKey: /etc/istio/ingressgateway-certs/tls.key
-
+        credentialName: ingress-tls-cert
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService

--- a/bookinfo-example/config/bookinfo-with-authservice-template.yaml
+++ b/bookinfo-example/config/bookinfo-with-authservice-template.yaml
@@ -266,7 +266,8 @@ spec:
         ports:
         - containerPort: 9080
       - name: authservice # authservice needs to be deployed in the sample Pod as the productpage
-        image: <AUTHSERVICE_IMAGE_REPLACE_ME> # Manually docker pull the latest authservice image from https://github.com/istio-ecosystem/authservice/packages and push it to your own image registry (e.g. Docker Hub), and use it here. (The Github Package Registry does not work with k8s yet until this issue is fixed and released: https://github.com/kubernetes-sigs/kind/issues/870)
+        # TODO(incfly): change to a proper project wide container registry.
+        image: gcr.io/jianfeih-images-pub/authservice/authservice:0.4.1 # Manually docker pull the latest authservice image from https://github.com/istio-ecosystem/authservice/packages and push it to your own image registry (e.g. Docker Hub), and use it here. (The Github Package Registry does not work with k8s yet until this issue is fixed and released: https://github.com/kubernetes-sigs/kind/issues/870)
         imagePullPolicy: Always
         ports:
           - containerPort: 10003

--- a/bookinfo-example/config/productpage-external-authz-envoyfilter-sidecar.yaml
+++ b/bookinfo-example/config/productpage-external-authz-envoyfilter-sidecar.yaml
@@ -25,7 +25,7 @@ spec:
           filter:
             name: "envoy.http_connection_manager"
             subFilter:
-              name: "envoy.filters.http.router" # simplify to not require add jwt policy for now.
+              name: "envoy.filters.http.jwt_authn"
     patch:
       operation: INSERT_BEFORE
       value:

--- a/bookinfo-example/config/productpage-external-authz-envoyfilter-sidecar.yaml
+++ b/bookinfo-example/config/productpage-external-authz-envoyfilter-sidecar.yaml
@@ -25,7 +25,7 @@ spec:
           filter:
             name: "envoy.http_connection_manager"
             subFilter:
-              name: "envoy.filters.http.jwt_authn"
+              name: "envoy.filters.http.router" # simplify to not require add jwt policy for now.
     patch:
       operation: INSERT_BEFORE
       value:

--- a/bookinfo-example/scripts/generate-self-signed-certs-for-ingress-gateway.sh
+++ b/bookinfo-example/scripts/generate-self-signed-certs-for-ingress-gateway.sh
@@ -2,14 +2,14 @@
 
 set -eu
 
-ingress_host=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-
 # Generate certs using openssl
-openssl req -outform PEM -out /tmp/key.crt.pem -new -keyout /tmp/key.pem -newkey rsa:2048 -batch -nodes -x509 -subj "/CN=${ingress_host}" -days 365
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem \
+ -days 365 -nodes -subj '/CN=localhost'
 
 # upload the certs by creating a k8s secret
-kubectl create -n istio-system secret tls istio-ingressgateway-certs --key /tmp/key.pem --cert /tmp/key.crt.pem
+kubectl create -n istio-system secret tls ingress-tls-cert --key=key.pem \
+  --cert=cert.pem
 
 # make sure the secret is correctly created
 echo; echo; echo "Verify that the secret is created:"
-kubectl get secret --all-namespaces | grep istio-ingressgateway-certs
+kubectl get secret -nistio-system | grep ingress-tls-cert

--- a/src/filters/filter_chain.cc
+++ b/src/filters/filter_chain.cc
@@ -65,10 +65,12 @@ std::unique_ptr<Filter> FilterChainImpl::New() {
           "only one filter of type \"oidc\" is allowed in a chain");
     }
 
+    auto jwks_keys = google::jwt_verify::Jwks::createFrom(
+            filter.oidc().jwks(), google::jwt_verify::Jwks::Type::JWKS);
+    spdlog::debug("status for jwks parsing: {}, {}", __func__,
+      google::jwt_verify::getStatusString(jwks_keys->getStatus()));
     auto token_request_parser = std::make_shared<oidc::TokenResponseParserImpl>(
-        google::jwt_verify::Jwks::createFrom(
-            filter.oidc().jwks(), google::jwt_verify::Jwks::Type::JWKS));
-
+        std::move(jwks_keys));
     auto session_string_generator =
         std::make_shared<common::session::SessionStringGenerator>();
 


### PR DESCRIPTION
This PR updates a few things.

- Use external authz provider, the CUSTOM action.
- Change to use credentialName instead of mounting secrets for ingress to host the OIDC callback URI.
- Other misc polishment such as logging the jwks parsing error and makefile IMAGE customization.