### PR TITLE
fix OOM while processing gRPC completion state

### DIFF
--- a/src/service/async_service_impl.cc
+++ b/src/service/async_service_impl.cc
@@ -86,10 +86,8 @@ void ProcessingState::Proceed() {
 void CompleteState::Proceed() {
   spdlog::trace("Processing completion and deleting state");
 
-  if (!processor_v2_) delete processor_v2_;
-
-  if (!processor_v3_) delete processor_v3_;
-
+  delete processor_v2_;
+  delete processor_v3_;
   delete this;
 }
 

--- a/src/service/async_service_impl.h
+++ b/src/service/async_service_impl.h
@@ -175,9 +175,9 @@ class ProcessingState : public ServiceState {
 class CompleteState : public ServiceState {
  public:
   explicit CompleteState(ProcessingStateV2 *processor)
-      : processor_v2_(processor) {}
+      : processor_v2_(processor), processor_v3_(nullptr) {}
   explicit CompleteState(ProcessingState *processor)
-      : processor_v3_(processor) {}
+      : processor_v2_(nullptr), processor_v3_(processor) {}
 
   void Proceed() override;
 


### PR DESCRIPTION
The reason for the OOM was that the ProcessingState pointer passed to CompletionState was not released properly. As a result of the fix, the memory pressure is as follows The load test was done as follows for bookinfo deployed in GKE.

### before
```
fortio load -H ${COOKIE} -qps 800 -t 6m -c 4 https://${AUTHORITY_NAME}/productpage
```

![Screenshot from 2021-10-08 18-02-19](https://user-images.githubusercontent.com/17607122/136529592-676fa3f2-1b27-4369-9123-f8ac5decd83d.png)

### after
```
fortio load -H ${COOKIE} -qps 6000 -t 6m -c 4 https://${AUTHORITY_NAME}/productpage
```

![Screenshot from 2021-10-08 18-02-07](https://user-images.githubusercontent.com/17607122/136529645-b71c9e88-358d-436f-afce-e4c986eb2ff4.png)
