### PR TITLE
replace numbered mock helper with un-numbered one

### DIFF
--- a/test/common/http/mocks.h
+++ b/test/common/http/mocks.h
@@ -9,21 +9,19 @@ namespace common {
 namespace http {
 class HttpMock : public Http {
  public:
-  MOCK_CONST_METHOD7(
-      Post,
-      response_t(absl::string_view uri,
-                 const std::map<absl::string_view, absl::string_view> &headers,
-                 absl::string_view body, absl::string_view ca_cert,
-                 absl::string_view proxy_uri, boost::asio::io_context &ioc,
-                 boost::asio::yield_context yield));
+  MOCK_METHOD(response_t, Post,
+              (absl::string_view,
+               (const std::map<absl::string_view, absl::string_view> &),
+               absl::string_view, absl::string_view, absl::string_view,
+               boost::asio::io_context &, boost::asio::yield_context),
+              (const));
 
-  MOCK_CONST_METHOD7(
-      Get,
-      response_t(absl::string_view uri,
-                 const std::map<absl::string_view, absl::string_view> &headers,
-                 absl::string_view body, absl::string_view ca_cert,
-                 absl::string_view proxy_uri, boost::asio::io_context &ioc,
-                 boost::asio::yield_context yield));
+  MOCK_METHOD(response_t, Get,
+              (absl::string_view,
+               (const std::map<absl::string_view, absl::string_view> &),
+               absl::string_view, absl::string_view, absl::string_view,
+               boost::asio::io_context &, boost::asio::yield_context),
+              (const));
 };
 }  // namespace http
 }  // namespace common

--- a/test/common/utilities/mocks.h
+++ b/test/common/utilities/mocks.h
@@ -10,7 +10,7 @@ namespace utilities {
 
 class TimeServiceMock : public TimeService {
  public:
-  MOCK_METHOD0(GetCurrentTimeInSecondsSinceEpoch, int64_t());
+  MOCK_METHOD(int64_t, GetCurrentTimeInSecondsSinceEpoch, ());
 };
 
 }  // namespace utilities

--- a/test/filters/oidc/mocks.h
+++ b/test/filters/oidc/mocks.h
@@ -15,38 +15,34 @@ namespace oidc {
 
 class SessionStoreMock final : public SessionStore {
  public:
-  MOCK_METHOD2(SetTokenResponse,
-               void(absl::string_view session_id,
-                    std::shared_ptr<TokenResponse> token_response));
+  MOCK_METHOD(void, SetTokenResponse,
+              (absl::string_view session_id, (std::shared_ptr<TokenResponse>)));
 
-  MOCK_METHOD1(GetTokenResponse,
-               std::shared_ptr<TokenResponse>(absl::string_view session_id));
+  MOCK_METHOD((std::shared_ptr<TokenResponse>), GetTokenResponse,
+              (absl::string_view));
 
-  MOCK_METHOD2(SetAuthorizationState,
-               void(absl::string_view session_id,
-                    std::shared_ptr<AuthorizationState> authorization_state));
+  MOCK_METHOD(void, SetAuthorizationState,
+              (absl::string_view, (std::shared_ptr<AuthorizationState>)));
 
-  MOCK_METHOD1(GetAuthorizationState, std::shared_ptr<AuthorizationState>(
-                                          absl::string_view session_id));
+  MOCK_METHOD((std::shared_ptr<AuthorizationState>), GetAuthorizationState,
+              (absl::string_view));
 
-  MOCK_METHOD1(ClearAuthorizationState, void(absl::string_view session_id));
+  MOCK_METHOD(void, ClearAuthorizationState, (absl::string_view));
 
-  MOCK_METHOD1(RemoveSession, void(absl::string_view session_id));
+  MOCK_METHOD(void, RemoveSession, (absl::string_view));
 
-  MOCK_METHOD0(RemoveAllExpired, void());
+  MOCK_METHOD(void, RemoveAllExpired, ());
 };
 
 class TokenResponseParserMock final : public TokenResponseParser {
  public:
-  MOCK_CONST_METHOD3(
-      Parse, std::shared_ptr<TokenResponse>(const std::string &client_id,
-                                            const std::string &nonce,
-                                            const std::string &raw));
+  MOCK_METHOD((std::shared_ptr<TokenResponse>), Parse,
+              (const std::string &client_id, const std::string &nonce,
+               const std::string &raw),
+              (const));
 
-  MOCK_CONST_METHOD2(ParseRefreshTokenResponse,
-                     std::shared_ptr<TokenResponse>(
-                         const TokenResponse &existing_token_response,
-                         const std::string &raw_response_string));
+  MOCK_METHOD((std::shared_ptr<TokenResponse>), ParseRefreshTokenResponse,
+              (const TokenResponse &, const std::string &), (const));
 };
 
 class RedisWrapperMock : public RedisWrapper {
@@ -55,30 +51,31 @@ class RedisWrapperMock : public RedisWrapper {
   // this is just enough to satisfy the constructor
   RedisWrapperMock() : RedisWrapper("tcp://127.0.0.1", 6){};
 
-  MOCK_METHOD2(hget, absl::optional<std::string>(const absl::string_view,
-                                                 const absl::string_view));
+  MOCK_METHOD(absl::optional<std::string>, hget,
+              (const absl::string_view, const absl::string_view));
 
-  MOCK_METHOD2(hmget,
-               std::unordered_map<std::string, absl::optional<std::string>>(
-                   const absl::string_view key,
-                   const std::vector<std::string> &fields));
+  MOCK_METHOD((std::unordered_map<std::string, absl::optional<std::string>>),
+              hmget,
+              (const absl::string_view, const std::vector<std::string> &));
 
-  MOCK_METHOD3(hset, bool(const absl::string_view, const absl::string_view,
-                          const absl::string_view));
+  MOCK_METHOD(bool, hset,
+              (const absl::string_view, const absl::string_view,
+               const absl::string_view));
 
-  MOCK_METHOD2(hmset, void(const absl::string_view key,
-                           const std::unordered_map<std::string, std::string>
-                               fields_to_values_map));
+  MOCK_METHOD(void, hmset,
+              (const absl::string_view,
+               (const std::unordered_map<std::string, std::string>)));
 
-  MOCK_METHOD3(hsetnx, bool(const absl::string_view, const absl::string_view,
-                            const absl::string_view));
+  MOCK_METHOD(bool, hsetnx,
+              (const absl::string_view, const absl::string_view,
+               const absl::string_view));
 
-  MOCK_METHOD1(del, long long(const absl::string_view));
+  MOCK_METHOD(long long, del, (const absl::string_view));
 
-  MOCK_METHOD2(hdel,
-               long long(const absl::string_view, std::vector<std::string> &));
+  MOCK_METHOD(long long, hdel,
+              (const absl::string_view, std::vector<std::string> &));
 
-  MOCK_METHOD2(expireat, bool(const absl::string_view, long long));
+  MOCK_METHOD(bool, expireat, (const absl::string_view, long long));
 };
 
 }  // namespace oidc


### PR DESCRIPTION
Signed-off-by: Shikugawa <Shikugawa@gmail.com>

We should utilize un-numbered mock helpers like envoy.