### PR TITLE
Update bookinfo example with operator.yaml example for easier setup.

### DIFF
--- a/bookinfo-example/README.md
+++ b/bookinfo-example/README.md
@@ -47,10 +47,12 @@ URI to be hosted on a protected endpoint.
    mesh: |-
       extensionProviders:
       - name: "authservice-grpc"
-         envoyExtAuthzGrpc:
-           service: authservice.default.svc.cluster.local
-           port: "10003"
+        envoyExtAuthzGrpc:
+          service: authservice.default.svc.cluster.local
+          port: "10003"
    ```
+
+   Alternatively you can install Istio with a sample [operator.yaml](https://github.com/istio-ecosystem/authservice/blob/master/bookinfo-example/authservice/istio-operatory.yaml) we provide when using `istioctl install -f istio-operator.yaml`.
 
 1. Fetch the identity provider public key and populate into the configmap. In our example, run
 `scripts/google-jwks.sh`.

--- a/bookinfo-example/authservice/istio-operator.yaml
+++ b/bookinfo-example/authservice/istio-operator.yaml
@@ -1,0 +1,10 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  profile: demo
+  meshConfig:
+    extensionProviders:
+    - name: "authservice-grpc"
+      envoyExtAuthzGrpc:
+        service: "authservice.default.svc.cluster.local"
+        port: "10003"


### PR DESCRIPTION
This also fixes the indentation problem in the sample config...