### PR TITLE
Add clang.bazelrc setup from envoy.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,4 +9,14 @@
 build --copt -DGRPC_BAZEL_BUILD
 build --cxxopt=-std=c++17
 
+# Clang with libc++
+build:libc++ --config=clang
+build:libc++ --action_env=CXXFLAGS=-stdlib=libc++
+build:libc++ --action_env=LDFLAGS=-stdlib=libc++
+build:libc++ --action_env=BAZEL_CXXOPTS=-stdlib=libc++
+build:libc++ --action_env=BAZEL_LINKLIBS=-l%:libc++.a:-l%:libc++abi.a
+build:libc++ --action_env=BAZEL_LINKOPTS=-lm:-pthread
+build:libc++ --define force_libcpp=enabled
+
+try-import %workspace%/clang.bazelrc
 try-import %workspace%/user.bazelrc

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 .vscode
 .idea
 .clwb
+clang.bazelrc
 /bazel-*
 .DS_Store
 /build_release
 /run/config/config.json
 user.bazelrc
 compile_commands.json
+

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ See the [Makefile](Makefile) for common tasks.
 
 If you are developing on a Mac, [this setup guide](https://github.com/istio-ecosystem/authservice/wiki/Setting-up-CLion-on-MacOS-for-Authservice-development) may be helpful.
 
+To build authservice with Clang, first setup the `clang.bazelrc` and then build the authservice with `--config=clang` option with bazel.
+
+```
+./bazel/setup_clang.sh <path-to-clang>
+bazel build //src/main:all  --config clang
+```
+
 ## Roadmap
 See the [authservice github Project](https://github.com/istio-ecosystem/authservice/projects/1)
 

--- a/bazel/BUILD.boost
+++ b/bazel/BUILD.boost
@@ -6,6 +6,13 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+config_setting(
+    name = "clang",
+    values = {
+        "define": "clang_cl=1",
+    },
+)
+
 load("@//bazel:boost.bzl", "new_boost_library")
 
 cc_library(

--- a/bazel/BUILD.boost
+++ b/bazel/BUILD.boost
@@ -9,7 +9,7 @@ config_setting(
 config_setting(
     name = "clang",
     values = {
-        "define": "clang_cl=1",
+        "action_env": "CXX=clang++",
     },
 )
 

--- a/bazel/boost.bzl
+++ b/bazel/boost.bzl
@@ -13,6 +13,10 @@ def boost_library(name, deps = []):
                     "libboost_{}.a".format(name),
                     "libboost_{}.dylib".format(name)
                 ],
+                "clang": [
+                    "libboost_{}.a".format(name),
+                    "libboost_{}.so.{}".format(name, BOOST_VERSION),
+                ],
                 "//conditions:default": [
                     "libboost_{}.a".format(name),
                     "libboost_{}.so.{}".format(name, BOOST_VERSION),
@@ -70,16 +74,25 @@ def boost_build_rule(name):
                     ROOT=$$(dirname $(location Jamroot))
                     cp $(location project-config.jam) $$ROOT
                     pushd $$ROOT
-                        ../../$(location b2) toolset=clang libboost_{name}.a libboost_{name}.dylib
+                        ../../$(location b2) libboost_{name}.a libboost_{name}.dylib
                     popd
                     cp $$ROOT/stage/lib/libboost_{name}.a $(location libboost_{name}.a)
                     cp $$ROOT/stage/lib/libboost_{name}.dylib $(location libboost_{name}.dylib)
                 """.format(name = name),
-                "//conditions:default": """
+                "clang": """
                     ROOT=$$(dirname $(location Jamroot))
                     cp $(location project-config.jam) $$ROOT
                     pushd $$ROOT
                         ../../$(location b2) toolset=clang libboost_{name}.a libboost_{name}.so.{version}
+                    popd
+                    cp $$ROOT/stage/lib/libboost_{name}.a $(location libboost_{name}.a)
+                    cp $$ROOT/stage/lib/libboost_{name}.so.{version} $(location libboost_{name}.so.{version})
+                """.format(name = name, version = BOOST_VERSION),
+                "//conditions:default": """
+                    ROOT=$$(dirname $(location Jamroot))
+                    cp $(location project-config.jam) $$ROOT
+                    pushd $$ROOT
+                        ../../$(location b2) libboost_{name}.a libboost_{name}.so.{version}
                     popd
                     cp $$ROOT/stage/lib/libboost_{name}.a $(location libboost_{name}.a)
                     cp $$ROOT/stage/lib/libboost_{name}.so.{version} $(location libboost_{name}.so.{version})

--- a/bazel/boost.bzl
+++ b/bazel/boost.bzl
@@ -70,7 +70,7 @@ def boost_build_rule(name):
                     ROOT=$$(dirname $(location Jamroot))
                     cp $(location project-config.jam) $$ROOT
                     pushd $$ROOT
-                        ../../$(location b2) libboost_{name}.a libboost_{name}.dylib
+                        ../../$(location b2) toolset=clang libboost_{name}.a libboost_{name}.dylib
                     popd
                     cp $$ROOT/stage/lib/libboost_{name}.a $(location libboost_{name}.a)
                     cp $$ROOT/stage/lib/libboost_{name}.dylib $(location libboost_{name}.dylib)
@@ -79,7 +79,7 @@ def boost_build_rule(name):
                     ROOT=$$(dirname $(location Jamroot))
                     cp $(location project-config.jam) $$ROOT
                     pushd $$ROOT
-                        ../../$(location b2) libboost_{name}.a libboost_{name}.so.{version}
+                        ../../$(location b2) toolset=clang libboost_{name}.a libboost_{name}.so.{version}
                     popd
                     cp $$ROOT/stage/lib/libboost_{name}.a $(location libboost_{name}.a)
                     cp $$ROOT/stage/lib/libboost_{name}.so.{version} $(location libboost_{name}.so.{version})

--- a/bazel/setup_clang.sh
+++ b/bazel/setup_clang.sh
@@ -23,7 +23,6 @@ build:clang --action_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config'
 build:clang --repo_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config'
 build:clang --linkopt='-L$(llvm-config --libdir)'
 build:clang --linkopt='-Wl,-rpath,$(llvm-config --libdir)'
-build:clang --define clang_cl=1
 
 build:clang-asan --action_env=ENVOY_UBSAN_VPTR=1
 build:clang-asan --copt=-fsanitize=vptr,function

--- a/bazel/setup_clang.sh
+++ b/bazel/setup_clang.sh
@@ -23,6 +23,7 @@ build:clang --action_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config'
 build:clang --repo_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config'
 build:clang --linkopt='-L$(llvm-config --libdir)'
 build:clang --linkopt='-Wl,-rpath,$(llvm-config --libdir)'
+build:clang --define clang_cl=1
 
 build:clang-asan --action_env=ENVOY_UBSAN_VPTR=1
 build:clang-asan --copt=-fsanitize=vptr,function

--- a/bazel/setup_clang.sh
+++ b/bazel/setup_clang.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# This script is adapted from https://github.com/envoyproxy/envoy/blob/main/bazel/setup_clang.sh.
+
+BAZELRC_FILE="${BAZELRC_FILE:-$(bazel info workspace)/clang.bazelrc}"
+
+LLVM_PREFIX=$1
+
+if [[ ! -e "${LLVM_PREFIX}/bin/llvm-config" ]]; then
+  echo "Error: cannot find llvm-config in ${LLVM_PREFIX}."
+  exit 1
+fi
+
+PATH="$("${LLVM_PREFIX}"/bin/llvm-config --bindir):${PATH}"
+export PATH
+
+RT_LIBRARY_PATH="$(dirname "$(find "$(llvm-config --libdir)" -name libclang_rt.ubsan_standalone_cxx-x86_64.a | head -1)")"
+
+echo "# Generated file, do not edit. If you want to disable clang, just delete this file.
+build:clang --action_env='PATH=${PATH}'
+build:clang --action_env=CC=clang
+build:clang --action_env=CXX=clang++
+build:clang --action_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config'
+build:clang --repo_env='LLVM_CONFIG=${LLVM_PREFIX}/bin/llvm-config'
+build:clang --linkopt='-L$(llvm-config --libdir)'
+build:clang --linkopt='-Wl,-rpath,$(llvm-config --libdir)'
+
+build:clang-asan --action_env=ENVOY_UBSAN_VPTR=1
+build:clang-asan --copt=-fsanitize=vptr,function
+build:clang-asan --linkopt=-fsanitize=vptr,function
+build:clang-asan --linkopt='-L${RT_LIBRARY_PATH}'
+build:clang-asan --linkopt=-l:libclang_rt.ubsan_standalone-x86_64.a
+build:clang-asan --linkopt=-l:libclang_rt.ubsan_standalone_cxx-x86_64.a
+" > "${BAZELRC_FILE}"


### PR DESCRIPTION
Signed-off-by: Jianfei Hu <hujianfei258@gmail.com>

#192 

FIPS boringssl requires clang to compile. This is the first step to setup the clang copmilation option.