### PR TITLE
Make it possible to run clang/fips build in container.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 SRCS=$(shell find . -name '*.cc')
 HDRS=$(shell find . -name '*.h')
 TARGET:=//src/main:auth_server
-BAZEL_FLAGS:= --verbose_failures
+BAZEL_FLAGS:=$(BAZEL_FLAGS)
 IMAGE?=authservice:$(USER)
 
 all: build test docs

--- a/README.md
+++ b/README.md
@@ -41,8 +41,21 @@ To build authservice with Clang, first setup the `clang.bazelrc` and then build 
 ```
 ./bazel/setup_clang.sh <path-to-clang>
 bazel build //src/main:all  --config clang
-# To Build with FIPS compliant version.
+```
+
+To Build with FIPS compliant version, add `--define boringssl=fips`.
+
+```
 bazel build //src/main:all  --config clang --define boringssl=fips
+```
+
+To build with a containeried environment, with customized bazel arguments.
+
+```
+export CONTAINER_REGISTRY=gcr.io/your-project
+docker build --build-arg bazel_flags="--config=clang" \
+  -t ${CONTAINER_REGISTRY}/authservice:latest \
+  -f ./build/Dockerfile.build .
 ```
 
 ## Roadmap

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -1,0 +1,35 @@
+
+# The docker image for the actual build process.
+# Copy in only the necessary files for building.
+FROM ghcr.io/istio-ecosystem/authservice/authservice-build-env:2021-11-26 as auth-builder
+COPY . /src/
+
+# Build auth binary.
+ARG bazel_flags=""
+WORKDIR /src
+RUN bash ./bazel/setup_clang.sh /usr/lib/llvm-12/
+RUN BAZEL_FLAGS=$bazel_flags make bazel-bin/src/main/auth_server
+
+# Create our final auth-server container image.
+FROM debian:buster
+RUN groupadd -r auth-server-grp && useradd -m -g auth-server-grp auth-server-usr
+
+# Install dependencies
+RUN apt update && apt upgrade -y && apt install -y --no-install-recommends \
+    ca-certificates  \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=auth-builder \
+     /src/bazel-bin/src/main/auth_server \
+     /src/bazel-bin/external/boost/libboost_chrono.so.1.70.0 \
+     /src/bazel-bin/external/boost/libboost_context.so.1.70.0 \
+     /src/bazel-bin/external/boost/libboost_coroutine.so.1.70.0 \
+     /src/bazel-bin/external/boost/libboost_thread.so.1.70.0 \
+     /app/
+
+ENV LD_LIBRARY_PATH=.
+RUN chgrp auth-server-grp /app/* && chown auth-server-usr /app/* && chmod u+x /app/*
+
+USER auth-server-usr
+WORKDIR /app
+ENTRYPOINT ["/app/auth_server"]

--- a/build/Dockerfile.builder
+++ b/build/Dockerfile.builder
@@ -1,37 +1,15 @@
-# Create a base image that compile bazel c++ projects
-FROM debian:buster as bazel-builder
+# The docker image for the build environment for authservice.
+FROM debian:buster
+
 COPY build/install-bazel.sh /build/
 RUN chmod +x /build/install-bazel.sh && /build/install-bazel.sh
-RUN apt-get update && apt-get -y install make cmake ninja-build build-essential
-
-# Copy in only the necessary files for building.
-FROM bazel-builder as auth-builder
-COPY . /src/
-
-# Build auth binary.
-WORKDIR /src
-RUN make bazel-bin/src/main/auth_server
-
-# Create our final auth-server container image.
-FROM debian:buster
-RUN groupadd -r auth-server-grp && useradd -m -g auth-server-grp auth-server-usr
-
-# Install dependencies
-RUN apt update && apt upgrade -y && apt install -y --no-install-recommends \
-    ca-certificates  \
+RUN apt-get update && \
+  apt-get -y install make cmake ninja-build build-essential \
+  curl gnupg lsb-release wget software-properties-common \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=auth-builder \
-     /src/bazel-bin/src/main/auth_server \
-     /src/bazel-bin/external/boost/libboost_chrono.so.1.70.0 \
-     /src/bazel-bin/external/boost/libboost_context.so.1.70.0 \
-     /src/bazel-bin/external/boost/libboost_coroutine.so.1.70.0 \
-     /src/bazel-bin/external/boost/libboost_thread.so.1.70.0 \
-     /app/
-
-ENV LD_LIBRARY_PATH=.
-RUN chgrp auth-server-grp /app/* && chown auth-server-usr /app/* && chmod u+x /app/*
-
-USER auth-server-usr
-WORKDIR /app
-ENTRYPOINT ["/app/auth_server"]
+# Install LLVM/Clang 12.
+RUN wget https://apt.llvm.org/llvm.sh && \
+  chmod +x llvm.sh && \
+  bash ./llvm.sh 12


### PR DESCRIPTION
Signed-off-by: Jianfei Hu <hujianfei258@gmail.com>

https://github.com/istio-ecosystem/authservice/issues/192. The PR covers:

1. Separate the build env docker image (Dockerfile.builder) with the actual building process and artficat dockerfile (Dockerfile.build)
2. In the dockerfile.builder installs the llvm 12.0.
3. necessary readme.md and the makefile change.

To test this PR, you can

```
gh pr checkout https://github.com/istio-ecosystem/authservice/pull/196
docker build --build-arg bazel_flags="--config=clang --define boringssl=fips" \
-t ${CONTAINER_REGISTRY}/authservice:latest \
-f ./build/Dockerfile.build .
```