### PR TITLE
Append -static-libgcc on Linux

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -103,12 +103,12 @@ jobs:
         # This downloads the required clang tooling when it is not downloaded yet.
         run: |
           make clang.bazelrc
-          echo "BAZEL_FLAGS=--config=clang" >> $GITHUB_ENV
+          echo "BAZEL_FLAGS=--config=libc++" >> $GITHUB_ENV
 
       # Set BAZEL_FLAGS to FIPS mode only when it is required.
       - name: Setup FIPS mode
         if: matrix.mode == 'clang-fips'
-        run: echo "BAZEL_FLAGS=--config=clang --define=boringssl=fips" >> $GITHUB_ENV
+        run: echo "BAZEL_FLAGS=--config=libc++ --define=boringssl=fips" >> $GITHUB_ENV
 
       - name: Run all tests
         run: make test

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -60,6 +60,7 @@ jobs:
           - "ubuntu-20.04"
         mode:
           - "default"
+          # On CI, by default, we use libc++.
           - "clang"
           - "clang-fips"
     steps:
@@ -112,3 +113,9 @@ jobs:
 
       - name: Run all tests
         run: make test
+
+      # Make sure we have static binary on Linux
+      - name: Require static binary
+        if: runner.os == 'Linux' && matrix.mode == 'clang'
+        run: |
+          make requirestatic

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,12 +65,12 @@ jobs:
         # This downloads the required clang tooling when it is not downloaded yet.
         run: |
           make clang.bazelrc
-          echo "BAZEL_FLAGS=--config=clang" >> $GITHUB_ENV
+          echo "BAZEL_FLAGS=--config=libc++" >> $GITHUB_ENV
 
       # Set BAZEL_FLAGS to FIPS mode only when it is required.
       - name: Setup FIPS mode
         if: matrix.mode == 'clang-fips'
-        run: echo "BAZEL_FLAGS=--config=clang --define=boringssl=fips" >> $GITHUB_ENV
+        run: echo "BAZEL_FLAGS=--config=libc++ --define=boringssl=fips" >> $GITHUB_ENV
 
       - name: Create artifacts # We strip the "v"-prefix from the current tag.
         run: VERSION=${GITHUB_REF#refs/tags/v} MODE=${{ matrix.mode }} make dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
           - "ubuntu-20.04"
         mode:
           - "default"
+          # By default we use libc++.
           - "clang"
           - "clang-fips"
     steps:
@@ -74,6 +75,24 @@ jobs:
 
       - name: Create artifacts # We strip the "v"-prefix from the current tag.
         run: VERSION=${GITHUB_REF#refs/tags/v} MODE=${{ matrix.mode }} make dist
+
+      - name: Require static binary
+        if: runner.os == 'Linux' && matrix.mode == 'clang'
+        run: |
+          make requirestatic
+
+      - name: Login to GitHub Container Registry
+        if: runner.os == 'Linux' && matrix.mode == 'clang'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.PAT }}
+
+      - name: Build and push image
+        if: runner.os == 'Linux' && matrix.mode == 'clang'
+        run: |
+          make image push
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,7 @@
 FROM gcr.io/distroless/cc:nonroot
 
 COPY ./build_release/auth_server /app/auth_server
-USER nonroot:nonroot
+# We can't use nonroot:nonroot here since in K8s:
+# https://github.com/kubernetes/kubernetes/blob/98eff192802a87c613091223f774a6c789543e74/pkg/kubelet/kuberuntime/security_context_others.go#L49.
+USER 65532:65532
 ENTRYPOINT ["/app/auth_server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Istio Authors
 # Licensed under the Apache License, Version 2.0 (the "License")
 
-FROM gcr.io/distroless/cc:nonroot
+FROM gcr.io/distroless/cc-debian11:nonroot
 
 COPY ./build_release/auth_server /app/auth_server
 # We can't use nonroot:nonroot here since in K8s:

--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,10 @@ dep-graph.dot:
 clang.bazelrc: bazel/clang.bazelrc.tmpl $(llvm-config) $(envsubst)
 	@$(envsubst) < $< > $@
 
+# This builds the stripped binary, and checks if the binary is statically linked.
+requirestatic: $(stripped_binary)
+	@test/exe/require_static.sh $(stripped_binary)
+
 # Catch all rules for Go-based tools.
 $(go_tools_dir)/%:
 	@printf "$(ansi_format_dark)" tools "installing $($(notdir $@)@v)..."

--- a/Makefile
+++ b/Makefile
@@ -102,10 +102,11 @@ docs: $(protodoc) ## Build docs
 	@$(protodoc) --directories=config=message --title="Configuration Options" --output="docs/README.md"
 	@grep -v '(validate.required)' docs/README.md > /tmp/README.md && mv /tmp/README.md docs/README.md
 
+PACKAGING ?= Dockerfile
 image: $(stripped_binary) ## Build the docker image
 	@mkdir -p build_release
 	@cp -f $(stripped_binary) build_release/$(binary_name)
-	@docker build . -t $(IMAGE)
+	@docker build . -t $(IMAGE) -f $(PACKAGING)
 
 push: image ## Push docker image to registry
 	@docker push $(IMAGE)

--- a/bazel/bazel.bzl
+++ b/bazel/bazel.bzl
@@ -2,13 +2,16 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
+# envoy_stdlib_deps appends "-static-libgcc" on Linux.
+load("@envoy//bazel:envoy_internal.bzl", "envoy_stdlib_deps")
+
 _DEFAULT_COPTS = ["-Wall", "-Wextra"]
 
 def authsvc_cc_library(name, deps = [], srcs = [], hdrs = [], copts = [], defines = [], includes = [], textual_hdrs = [], visibility = None):
     cc_library(name = name, deps = deps, srcs = srcs, hdrs = hdrs, copts = _DEFAULT_COPTS + copts, defines = defines, includes = includes, textual_hdrs = textual_hdrs, visibility = visibility)
 
 def authsvc_cc_binary(name, deps = [], srcs = [], copts = [], defines = []):
-    cc_binary(name = name, deps = deps, srcs = srcs, copts = _DEFAULT_COPTS + copts, defines = defines)
+    cc_binary(name = name, deps = deps + envoy_stdlib_deps(), srcs = srcs, copts = _DEFAULT_COPTS + copts, defines = defines)
 
 def authsvc_cc_test(name, deps = [], srcs = [], data = []):
     cc_test(

--- a/bazel/bazel.bzl
+++ b/bazel/bazel.bzl
@@ -10,6 +10,7 @@ _DEFAULT_COPTS = ["-Wall", "-Wextra"]
 def authsvc_cc_library(name, deps = [], srcs = [], hdrs = [], copts = [], defines = [], includes = [], textual_hdrs = [], visibility = None):
     cc_library(name = name, deps = deps, srcs = srcs, hdrs = hdrs, copts = _DEFAULT_COPTS + copts, defines = defines, includes = includes, textual_hdrs = textual_hdrs, visibility = visibility)
 
+# By default, we always do linkstatic: https://docs.bazel.build/versions/main/be/c-cpp.html#cc_binary.linkstatic.
 def authsvc_cc_binary(name, deps = [], srcs = [], copts = [], defines = []):
     cc_binary(name = name, deps = deps + envoy_stdlib_deps(), srcs = srcs, copts = _DEFAULT_COPTS + copts, defines = defines)
 

--- a/test/exe/require_static.sh
+++ b/test/exe/require_static.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [[ $(uname) == "Darwin" ]]; then
+  echo "macOS doesn't support statically linked binaries, skipping."
+  exit 0
+fi
+
+echo "checking $1"
+
+# We can't rely on the exit code alone, since ldd fails for statically linked binaries.
+DYNLIBS=$(ldd "$1" 2>&1) || {
+  if [[ ! "${DYNLIBS}" =~ 'not a dynamic executable' ]]; then
+      echo "${DYNLIBS}"
+      exit 1
+  fi
+}
+
+if [[ "${DYNLIBS}" =~ libc\+\+ ]]; then
+  echo "libc++ is dynamically linked:"
+  echo "${DYNLIBS}"
+  exit 1
+elif [[ "${DYNLIBS}" =~ libstdc\+\+ || "${DYNLIBS}" =~ libgcc ]]; then
+  echo "libstdc++ and/or libgcc are dynamically linked:"
+  echo "${DYNLIBS}"
+  exit 1
+fi
+
+echo "success"

--- a/test/exe/require_static.sh
+++ b/test/exe/require_static.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Copied from https://github.com/envoyproxy/envoy/blob/a12869fa9e9add4301a700978d5489e6a0cc0526/test/exe/envoy_static_test.sh.
+
 if [[ $(uname) == "Darwin" ]]; then
   echo "macOS doesn't support statically linked binaries, skipping."
   exit 0

--- a/test/exe/require_static.sh
+++ b/test/exe/require_static.sh
@@ -5,8 +5,6 @@ if [[ $(uname) == "Darwin" ]]; then
   exit 0
 fi
 
-echo "checking $1"
-
 # We can't rely on the exit code alone, since ldd fails for statically linked binaries.
 DYNLIBS=$(ldd "$1" 2>&1) || {
   if [[ ! "${DYNLIBS}" =~ 'not a dynamic executable' ]]; then
@@ -24,5 +22,3 @@ elif [[ "${DYNLIBS}" =~ libstdc\+\+ || "${DYNLIBS}" =~ libgcc ]]; then
   echo "${DYNLIBS}"
   exit 1
 fi
-
-echo "success"


### PR DESCRIPTION
This patch makes sure we do: "-static-libgcc" on Linux (for the stripped binary). We also use `--config libc++` (instead of `--config clang`) to link against `libc++` on CI (Linux).

This also adds a workflow to publish the Docker image. 

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>