### PR TITLE
Fix the unmatched request handling by set the grpc status in payload.

### DIFF
--- a/bookinfo-example/authservice/templates/config.yaml
+++ b/bookinfo-example/authservice/templates/config.yaml
@@ -20,9 +20,14 @@ data:
       "listen_port": "10003",
       "log_level": "trace",
       "threads": 8,
+      "allow_unmatched_requests": "false",
       "chains": [
         {
           "name": "idp_filter_chain",
+          "match": {
+            "header": ":authority",
+            "prefix": "test.example.com",
+          },
           "filters": [
           {
             "oidc":

--- a/bookinfo-example/authservice/templates/config.yaml
+++ b/bookinfo-example/authservice/templates/config.yaml
@@ -26,7 +26,7 @@ data:
           "name": "idp_filter_chain",
           "match": {
             "header": ":authority",
-            "prefix": "test.example.com",
+            "prefix": "localhost",
           },
           "filters": [
           {

--- a/src/service/BUILD
+++ b/src/service/BUILD
@@ -35,6 +35,7 @@ authsvc_cc_library(
         "@com_github_gabime_spdlog//:spdlog",
         "@com_github_grpc_grpc//:grpc++",
         "@envoy//source/common/config:version_converter_lib",
+        # "@envoy//envoy/grpc:status",
         "@envoy_api//envoy/service/auth/v2:pkg_cc_grpc",
         "@envoy_api//envoy/service/auth/v3:pkg_cc_grpc",
     ],

--- a/src/service/async_service_impl.cc
+++ b/src/service/async_service_impl.cc
@@ -18,7 +18,7 @@ namespace {
 constexpr uint16_t kHealthCheckServerPort = 10004;
 }
 
-::grpc::Status convertGrpcStatus(const google::rpc::Code status)  {
+::grpc::Status convertGrpcStatus(const google::rpc::Code status) {
   // See src/filters/filter.h:filter::Process for a description of how
   // status codes should be handled
   switch (status) {

--- a/src/service/async_service_impl.h
+++ b/src/service/async_service_impl.h
@@ -23,6 +23,8 @@
 namespace authservice {
 namespace service {
 
+::grpc::Status convertGrpcStatus(const google::rpc::Code status);
+
 template <class RequestType, class ResponseType>
 ::grpc::Status Check(
     const RequestType &request, ResponseType &response,
@@ -60,17 +62,6 @@ template <class RequestType, class ResponseType>
       return ::grpc::Status::OK;
     }
 
-    // TODO(incfly): Clean up trigger rule after checking the current Istio
-    // ExtAuthz API is sufficient.
-    const auto default_response_code =
-        allow_unmatched_requests
-            ? grpc::Status::OK
-            : grpc::Status(grpc::StatusCode::PERMISSION_DENIED,
-                           "permission denied");
-    spdlog::debug("jianfeih debug allow unmatched or not: {}, foo {}, msg {}",
-                  allow_unmatched_requests, default_response_code.ok(),
-                  default_response_code.error_message());
-
     // Find a configured processing chain.
     for (auto &chain : chains) {
       if (chain->Matches(&request_v3)) {
@@ -84,7 +75,6 @@ template <class RequestType, class ResponseType>
         // Create a new instance of a processor.
         auto processor = chain->New();
         auto status = processor->Process(&request_v3, &response_v3, ioc, yield);
-
         // response v2/v3 conversion layer
         if constexpr (std::is_same_v<
                           ResponseType,
@@ -101,53 +91,45 @@ template <class RequestType, class ResponseType>
                                   ::envoy::service::auth::v3::CheckResponse>) {
           response = response_v3;
         }
-
-        // See src/filters/filter.h:filter::Process for a description of how
-        // status codes should be handled
-        switch (status) {
-          case google::rpc::Code::OK:  // The request was successful
-          case google::rpc::Code::UNAUTHENTICATED:    // A filter indicated the
-                                                      // request had no
-                                                      // authentication but was
-                                                      // processed correctly.
-          case google::rpc::Code::PERMISSION_DENIED:  // A filter indicated
-            // insufficient permissions
-            // for the authenticated
-            // requester but was processed
-            // correctly.
-            return ::grpc::Status::OK;
-          case google::rpc::Code::INVALID_ARGUMENT:  // The request was not well
-            // formed. Indicate a
-            // processing error to the
-            // caller.
-            return ::grpc::Status(::grpc::StatusCode::INVALID_ARGUMENT,
-                                  "invalid request");
-          default:  // All other errors are treated as internal processing
-                    // failures.
-            return ::grpc::Status(::grpc::StatusCode::INTERNAL,
-                                  "internal error");
-        }
+        return convertGrpcStatus(status);
       }
     }
+    // No matching filter chain found.
 
-    // No matching filter chain found. Allow request to continue.
+    // TODO(incfly): Clean up trigger rule after checking the current Istio
+    // ExtAuthz API is sufficient.
+    auto default_response_code =
+        grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "permission denied");
+    google::rpc::Code code = google::rpc::Code::PERMISSION_DENIED;
+    if (allow_unmatched_requests) {
+      default_response_code = grpc::Status::OK;
+      code = google::rpc::Code::OK;
+    }
+    envoy::service::auth::v2::CheckResponse response_v2;
+    envoy::service::auth::v3::CheckResponse response_v3;
+    response_v2.mutable_status()->set_code(code);
+    response_v3.mutable_status()->set_code(code);
+    if constexpr (std::is_same_v<ResponseType,
+                                 ::envoy::service::auth::v2::CheckResponse>) {
+      response = response_v2;
+    } else if (std::is_same_v<ResponseType,
+                              ::envoy::service::auth::v3::CheckResponse>) {
+      response = response_v3;
+    }
+
+    if constexpr (std::is_same_v<ResponseType,
+                                 ::envoy::service::auth::v3::CheckResponse>) {
+      response = response_v3;
+    }
+
     spdlog::debug(
-        "{}: jianfeih here1, no matching filter chain for request to "
-        "{}://{}{}, respond with: "
+        "{}: no matching filter chain for request to "
+        "{}://{}{}, allow_unmatched_requests {}, respond with: "
         "{}",
         __func__, request.attributes().request().http().scheme(),
         request.attributes().request().http().host(),
-        request.attributes().request().http().path(),
+        request.attributes().request().http().path(), allow_unmatched_requests,
         default_response_code.error_code());
-    // TODO: not just here all the response code needs to be modified.
-    if constexpr (std::is_same_v<ResponseType,
-                                 ::envoy::service::auth::v3::CheckResponse>) {
-      spdlog::debug("jianfeih debug setting status happening.");
-      envoy::service::auth::v3::CheckResponse response_v3;
-      response_v3.mutable_status()->set_code(7);
-      // Grpc::Status::WellKnownGrpcStatus::PermissionDenied);
-      // response = response_v3;
-    }
     return default_response_code;
   } catch (const std::exception &exception) {
     spdlog::error("%s unexpected error: %s", __func__, exception.what());


### PR DESCRIPTION
Fix #140 

Previously we only return the grpc status, but not set the actual response payload, `response.status`.
Verified works manually e2e with `allow_unmatched_request: true/false` having different effect.

