### PR TITLE
Use @envoy//bazel:boringssl

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -60,6 +60,8 @@ def boost():
         urls = [
             "https://github.com/nelhage/rules_boost/archive/%s.tar.gz" % _RULES_BOOST_COMMIT,
         ],
+        patches = ["//bazel:rules_boost.patch"],
+        patch_args = ["-p1"],
     )
 
 def com_github_redis_hiredis():

--- a/bazel/rules_boost.patch
+++ b/bazel/rules_boost.patch
@@ -1,0 +1,14 @@
+# To make sure we use the provided @envoy//bazel:boringssl.
+diff --git a/BUILD.boost b/BUILD.boost
+index 4354973..1c11525 100644
+--- a/BUILD.boost
++++ b/BUILD.boost
+@@ -481,7 +481,7 @@ cc_library(
+     visibility = ["//visibility:public"],
+     deps = [
+         ":asio",
+-        "@openssl//:ssl",
++        "@envoy//bazel:boringssl",
+     ],
+ )
+


### PR DESCRIPTION
This makes sure we use @envoy//bazel:boringssl.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>