### PR TITLE
Ignore CERT_ALREADY_IN_HASH_TABLE error

### DIFF
--- a/src/common/http/http.cc
+++ b/src/common/http/http.cc
@@ -424,11 +424,11 @@ response_t HttpImpl::Post(
           boost::asio::buffer(options.ca_cert_.data(), options.ca_cert_.size()),
           ca_ec);
       if (ca_ec) {
-        auto err = ERR_get_error();
+        std::string ca_message = ca_ec.message();
+        bool hash_error = ca_message.find("CERT_ALREADY_IN_HASH_TABLE") != std::string::npos;
         // We can ignore this error. Reference:
         // https://github.com/facebook/folly/blob/d3354e2282303402e70d829d19bfecce051a5850/folly/ssl/OpenSSLCertUtils.cpp#L367-L368.
-        if (ERR_GET_LIB(err) != ERR_LIB_X509 ||
-            ERR_GET_REASON(err) != X509_R_CERT_ALREADY_IN_HASH_TABLE) {
+        if (!hash_error) {
           throw boost::system::system_error{ca_ec};
         }
       }
@@ -549,7 +549,13 @@ response_t HttpImpl::Get(
           boost::asio::buffer(options.ca_cert_.data(), options.ca_cert_.size()),
           ca_ec);
       if (ca_ec) {
-        throw boost::system::system_error{ca_ec};
+        std::string ca_message = ca_ec.message();
+        bool hash_error = ca_message.find("CERT_ALREADY_IN_HASH_TABLE") != std::string::npos;
+        // We can ignore this error. Reference:
+        // https://github.com/facebook/folly/blob/d3354e2282303402e70d829d19bfecce051a5850/folly/ssl/OpenSSLCertUtils.cpp#L367-L368.
+        if (!hash_error) {
+          throw boost::system::system_error{ca_ec};
+        }
       }
     }
 


### PR DESCRIPTION
Check ec value for CERT_ALREADY_IN_HASH_TABLE instead of using ERR_get_error.
