### PR TITLE
Enable FIPS for Linux only

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false # don't fail fast as sometimes failures are operating system specific.
       matrix:
         os:
-          - "macos-11"
+          - "macos-12"
           - "ubuntu-18.04"
         mode:
           - "default"
@@ -100,7 +100,7 @@ jobs:
 
       # Prepare clang tooling and config when it is required.
       - name: Setup clang
-        if: matrix.mode == 'clang' || matrix.mode == 'clang-fips'
+        if: runner.os == 'Linux' && (matrix.mode == 'clang' || matrix.mode == 'clang-fips')
         # This downloads the required clang tooling when it is not downloaded yet.
         run: |
           make clang.bazelrc
@@ -108,7 +108,7 @@ jobs:
 
       # Set BAZEL_FLAGS to FIPS mode only when it is required.
       - name: Setup FIPS mode
-        if: matrix.mode == 'clang-fips'
+        if: runner.os == 'Linux' && matrix.mode == 'clang-fips'
         run: echo "BAZEL_FLAGS=--config=libc++ --define=boringssl=fips" >> $GITHUB_ENV
 
       - name: Run all tests

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -55,14 +55,13 @@ jobs:
     strategy:
       fail-fast: false # don't fail fast as sometimes failures are operating system specific.
       matrix:
-        os:
-          - "macos-11"
-          - "ubuntu-18.04"
-        mode:
-          - "default"
-          # On CI, by default, we use libc++.
-          - "clang"
-          - "clang-fips"
+        include:
+          - os: macos-11
+            mode: default
+          - os: ubuntu-18.04
+            mode: clang
+          - os: ubuntu-18.04
+            mode: clang-fips
     steps:
       - name: Cancel when duplicated
         uses: styfle/cancel-workflow-action@0.4.1

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false # don't fail fast as sometimes failures are operating system specific.
       matrix:
         os:
-          - "macos-12"
+          - "macos-11"
           - "ubuntu-18.04"
         mode:
           - "default"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,7 +119,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            dist-Linux-default/**/*.tar.gz
             dist-Linux-clang/**/*.tar.gz
             dist-Linux-clang-fips/**/*.tar.gz
             dist-macOS-default/**/*.tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
 
       # Prepare clang tooling and config when it is required.
       - name: Setup clang
-        if: matrix.mode == 'clang' || matrix.mode == 'clang-fips'
+        if: runner.os == 'Linux' && (matrix.mode == 'clang' || matrix.mode == 'clang-fips')
         # This downloads the required clang tooling when it is not downloaded yet.
         # GITHUB_REF: refs/tags/0.5.1-rc1, resulted VERSION: "0.5.1".
         run: |
@@ -72,7 +72,7 @@ jobs:
 
       # Set BAZEL_FLAGS to FIPS mode only when it is required.
       - name: Setup FIPS mode
-        if: matrix.mode == 'clang-fips'
+        if: runner.os == 'Linux' && matrix.mode == 'clang-fips'
         run: echo "BAZEL_FLAGS=--config=libc++ --define=boringssl=fips" >> $GITHUB_ENV
 
       - name: Create artifacts
@@ -124,5 +124,3 @@ jobs:
             dist-Linux-clang/**/*.tar.gz
             dist-Linux-clang-fips/**/*.tar.gz
             dist-macOS-default/**/*.tar.gz
-            dist-macOS-clang/**/*.tar.gz
-            dist-macOS-clang-fips/**/*.tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,14 +17,13 @@ jobs:
     strategy:
       fail-fast: false # don't fail fast as sometimes failures are operating system specific.
       matrix:
-        os:
-          - "macos-11"
-          - "ubuntu-18.04"
-        mode:
-          - "default"
-          # By default we use libc++.
-          - "clang"
-          - "clang-fips"
+        include:
+          - os: macos-11
+            mode: default
+          - os: ubuntu-18.04
+            mode: clang
+          - os: ubuntu-18.04
+            mode: clang-fips
     steps:
       - name: Cancel when duplicated
         uses: styfle/cancel-workflow-action@0.4.1

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ main_target     := //src/main:$(binary_name)
 # Always use amd64 for bazelisk for build and test rules below, since we don't support for macOS
 # arm64 (with --host_javabase=@local_jdk//:jdk) yet (especially the protoc-gen-validate project:
 # "no matching toolchains found for types @io_bazel_rules_go//go:toolchain").
-bazel        := GOARCH=amd64 $(go) run $(bazelisk@v) --output_user_root=$(bazel_cache_dir)
+bazel        := GOARCH=amd64 $(go) run $(bazelisk@v) $(if $(CI),--output_user_root=$(bazel_cache_dir),)
 buildifier   := $(go_tools_dir)/buildifier
 envsubst     := $(go_tools_dir)/envsubst
 protodoc     := $(go_tools_dir)/protodoc
@@ -90,7 +90,7 @@ build-%:
 dist: dist/$(binary_name)_$(goos)_amd64_$(MODE)_$(VERSION).tar.gz
 
 # Since we don't do cross-compilation yet (probably we can do it later via `zig cc`), we can only
-# build artifact for the current `os` and `mode` pair (e.g. {os: 'macOS', mode: 'clang-fips'}).
+# build artifact for the current `os` and `mode` pair (e.g. {os: 'linux', mode: 'clang-fips'}).
 dist/$(binary_name)_$(goos)_amd64_$(MODE)_$(VERSION).tar.gz: $(stripped_binary) ## Create build artifacts
 	@$(eval DIST_DIR := $(shell mktemp -d))
 	@cp -f LICENSE $(DIST_DIR)


### PR DESCRIPTION
The FIPS mode is only relevant for clang and Linux x68_64.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>