### PR TITLE
Pass the trusted CA from the OIDC config to the HTTP GET call just like POST

### DIFF
--- a/config/oidc/config.proto
+++ b/config/oidc/config.proto
@@ -93,6 +93,11 @@ message OIDCConfig {
         // true in any other cases.
         // Optional.
         bool skip_verify_peer_cert = 3;
+
+        // When specified, the Authservice will trust the specified Certificate Authority when performing HTTPS calls to
+        // the Token Endpoint of the OIDC Identity Provider.
+        // Optional.
+        string trusted_certificate_authority = 4;
     }
 
     oneof jwks_config {

--- a/src/filters/oidc/jwks_resolver.h
+++ b/src/filters/oidc/jwks_resolver.h
@@ -77,7 +77,7 @@ class DynamicJwksResolverImpl : public JwksResolver {
     boost::asio::io_context& ioc_;
     std::chrono::seconds periodic_fetch_interval_sec_;
     boost::asio::steady_timer timer_;
-    bool verify_peer_cert_ = false;
+    const config::oidc::OIDCConfig::JwksFetcherConfig config_;
   };
 
   explicit DynamicJwksResolverImpl(


### PR DESCRIPTION
The GET call does not provide the trusted CA cert in `opt` to the HTTP GET call. Setting `ca_cert` to the provided value in the OIDC config