### PR TITLE
Allow customizing the Istio version to use in the e2e tests

### DIFF
--- a/e2e/istio/Makefile
+++ b/e2e/istio/Makefile
@@ -15,6 +15,9 @@
 include ../suite-certs.mk
 include ../suite-k8s.mk
 
+# Version of Istio to install. If empty, the latest version will be installed.
+E2E_ISTIO_VERSION ?=
+
 .PHONY: gen-certs
 gen-certs: clean-certs ca/ca.authservice.internal certificate/http-echo.authservice.internal
 	@chmod -R a+r $(CERTS_DIR)

--- a/e2e/istio/suite_test.go
+++ b/e2e/istio/suite_test.go
@@ -17,6 +17,7 @@ package istio
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -30,6 +31,7 @@ import (
 )
 
 const (
+	istioHelmRepo = "https://istio-release.storage.googleapis.com/charts"
 	istiodConfig  = "cluster/istiod-config.yaml"
 	istioGwConfig = "cluster/istiogw-config.yaml"
 	manifestsDir  = "cluster/manifests"
@@ -46,23 +48,21 @@ var testManifests = []string{
 	"telemetry.yaml",
 }
 
-// istioInstall contains the commands to install Istio using Helm, so we don't require
-// downloading `istioctl` or other tooling that would just make the e2e tests take more time.
-var istioInstall = []string{
-	"helm repo add istio https://istio-release.storage.googleapis.com/charts --force-update",
-	"helm repo update istio",
-	fmt.Sprintf("helm --kubeconfig %s install istio-base istio/base -n istio-system --create-namespace", e2e.KubeConfig),
-	fmt.Sprintf("helm --kubeconfig %s install istiod istio/istiod -n istio-system -f %s --wait", e2e.KubeConfig, istiodConfig),
-	fmt.Sprintf("helm --kubeconfig %s install istio-ingress istio/gateway -n istio-system -f %s --wait", e2e.KubeConfig, istioGwConfig),
-}
-
 // IstioSuite is a suite that installs Istio in the Kubernetes cluster and runs tests against it.
 type IstioSuite struct {
 	e2e.K8sSuite
+	IstioVersion       string
+	IstioConfigValues  string
+	IstioGatewayValues string
 }
 
 func TestIstio(t *testing.T) {
-	suite.Run(t, &IstioSuite{})
+	suite.Run(t, &IstioSuite{
+		// If the IstioVersion is empty, the latest version will be installed
+		IstioVersion:       os.Getenv("E2E_ISTIO_VERSION"),
+		IstioConfigValues:  istiodConfig,
+		IstioGatewayValues: istioGwConfig,
+	})
 }
 
 // SetupSuite initializes the Kubernetes clients, installs Istio in the cluster and waits until the
@@ -77,7 +77,7 @@ func (i *IstioSuite) SetupSuite() {
 	// and make e2e tests easier to run multiple times without tearing down the entire
 	// environment
 	if !i.istioInstalled(client) {
-		i.installistio()
+		i.installIstio()
 	}
 
 	i.T().Log("deploying the test services...")
@@ -90,8 +90,20 @@ func (i *IstioSuite) SetupSuite() {
 	i.WaitForPods(client, "http-echo", "", corev1.PodRunning, e2e.PodReady)
 }
 
-func (i *IstioSuite) installistio() {
-	i.T().Log("installing Istio...")
+func (i *IstioSuite) installIstio() {
+	if i.IstioVersion == "" {
+		i.T().Log("installing Istio (latest)...")
+	} else {
+		i.T().Logf("installing Istio %s...", i.IstioVersion)
+	}
+
+	var istioInstall = []string{
+		fmt.Sprintf("helm repo add istio %s --force-update", istioHelmRepo),
+		"helm repo update istio",
+		i.helmInstall("istio-base", "istio/base", ""),
+		i.helmInstall("istiod", "istio/istiod", istiodConfig),
+		i.helmInstall("istio-ingress", "istio/gateway", istioGwConfig),
+	}
 
 	for _, cmd := range istioInstall {
 		parts := strings.Split(cmd, " ")
@@ -103,4 +115,13 @@ func (i *IstioSuite) installistio() {
 func (i *IstioSuite) istioInstalled(client kubernetes.Interface) bool {
 	_, err := client.CoreV1().Services("istio-system").Get(context.Background(), "istiod", metav1.GetOptions{})
 	return err == nil
+}
+
+func (i *IstioSuite) helmInstall(name, chart, values string) string {
+	cmd := fmt.Sprintf("helm --kubeconfig %s install %s %s --version %s -n istio-system --create-namespace --wait",
+		e2e.KubeConfig, name, chart, i.IstioVersion)
+	if values != "" {
+		cmd += fmt.Sprintf(" -f %s", values)
+	}
+	return cmd
 }


### PR DESCRIPTION
Currently, the e2e test suite runs against the latest Istio version. This change allows setting the `E2E_ISTIO_VERSION` to the version of Istio to be used. If left empty (default) the latest Istio version will still be installed.

It can be used as:
```bash
E2E_ISTIO_VERSION=1.21.0 E2E_TEST_OPTS=-v make e2e/istio
```