### PR TITLE
Upgrade Go to 1.22.2 to get rid of CVE-2023-45288

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/istio-ecosystem/authservice
 
-go 1.21.8
+go 1.22.2
 
 require (
 	github.com/alicebob/miniredis/v2 v2.31.1


### PR DESCRIPTION
Upgrade to the latest version of Go to get rid of CVE-2023-45288 in our docker images.