### PR TITLE
Configure nightly vulnerability scans and report upload

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -15,6 +15,7 @@
 name: Scan
 
 on:
+  # Run scans on all commits and PRs to verify new codes does not introduce new vulnerabilities.
   push:
     branches:
       - main
@@ -24,6 +25,9 @@ on:
     branches:
       - main
       - release-**
+  # Run nightly scans to upload any new CVEs to the security advisories
+  schedule:
+    - cron: "0 0 * * *"
   workflow_dispatch: {}
 
 env:
@@ -44,6 +48,13 @@ jobs:
       - uses: actions/checkout@v4
       - run: make docker
       - uses: anchore/scan-action@v3
+        id: scan
         with:
           image: local/authservice:scan-amd64
-          output-format: table
+      - run: cat ${{ steps.scan.outputs.sarif }}
+      # Do not upload the security advisories on every commit or pull request.
+      # Upload the security advisories only for the nightly scans.
+      - uses: github/codeql-action/upload-sarif@v3
+        if: ${{ github.event_name == 'schedule' }}
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}


### PR DESCRIPTION
Configures the scan action to run nightly and to upload the findings to the [security advisory page](https://github.com/istio-ecosystem/authservice/security/code-scanning). This will give proper visibility for any CVEs that may affect the project and help get them fixed.