### PR TITLE
Infer the JWS signing algorithm name by looking at the provided key

### DIFF
--- a/internal/authz/oidc.go
+++ b/internal/authz/oidc.go
@@ -621,7 +621,7 @@ func (o *oidcHandler) isValidIDToken(ctx context.Context, log telemetry.Logger, 
 		return false, codes.Internal
 	}
 
-	if _, err := jws.Verify([]byte(idTokenString), jws.WithKeySet(jwtSet)); err != nil {
+	if _, err := jws.Verify([]byte(idTokenString), jws.WithKeySet(jwtSet, jws.WithInferAlgorithmFromKey(true))); err != nil {
 		log.Error("error verifying id token with fetched jwks", err)
 		return false, codes.Internal
 	}

--- a/internal/authz/oidc.go
+++ b/internal/authz/oidc.go
@@ -621,6 +621,8 @@ func (o *oidcHandler) isValidIDToken(ctx context.Context, log telemetry.Logger, 
 		return false, codes.Internal
 	}
 
+	// We use jws.WithInferAlgorithmFromKey(true) in case the keys are missing the "alg" value;
+	// some providers (e.g. Microsoft Identity) exclude the "alg" value from their keys.
 	if _, err := jws.Verify([]byte(idTokenString), jws.WithKeySet(jwtSet, jws.WithInferAlgorithmFromKey(true))); err != nil {
 		log.Error("error verifying id token with fetched jwks", err)
 		return false, codes.Internal

--- a/internal/authz/oidc_test.go
+++ b/internal/authz/oidc_test.go
@@ -195,9 +195,12 @@ func TestOIDCProcess(t *testing.T) {
 	unknownJWKPriv, _ := newKeyPair(t)
 	jwkPriv, jwkPub := newKeyPair(t)
 	noAlgJwkPriv, noAlgJwkPub := newKeyPair(t)
-	noAlgJwkPriv.Set(jwk.KeyIDKey, noAlgKeyId)
-	noAlgJwkPub.Set(jwk.KeyIDKey, noAlgKeyId)
-	noAlgJwkPub.Remove(jwk.AlgorithmKey)
+	err := noAlgJwkPriv.Set(jwk.KeyIDKey, noAlgKeyID)
+	require.NoError(t, err)
+	err = noAlgJwkPub.Set(jwk.KeyIDKey, noAlgKeyID)
+	require.NoError(t, err)
+	err = noAlgJwkPub.Remove(jwk.AlgorithmKey)
+	require.NoError(t, err)
 
 	bytes, err := json.Marshal(newKeySet(t, jwkPub, noAlgJwkPub))
 	require.NoError(t, err)
@@ -1429,7 +1432,7 @@ func modifyCallbackRequestPath(path string) *envoy.CheckRequest {
 const (
 	keyID      = "test"
 	keyAlg     = jwa.RS256
-	noAlgKeyId = "noAlgTest"
+	noAlgKeyID = "noAlgTest"
 )
 
 func newKeySet(t *testing.T, keys ...jwk.Key) jwk.Set {

--- a/internal/authz/oidc_test.go
+++ b/internal/authz/oidc_test.go
@@ -194,6 +194,9 @@ func TestOIDCProcess(t *testing.T) {
 
 	unknownJWKPriv, _ := newKeyPair(t)
 	jwkPriv, jwkPub := newKeyPair(t)
+	// We remove the optional "alg" field from this key to test that we can
+	// properly validate against them. Some providers (e.g. Microsoft Identity)
+	// exclude the "alg" field from their keys.
 	noAlgJwkPriv, noAlgJwkPub := newKeyPair(t)
 	err := noAlgJwkPriv.Set(jwk.KeyIDKey, noAlgKeyID)
 	require.NoError(t, err)


### PR DESCRIPTION
This handles cases where the JWS message or the key do not have a proper `alg` header. The `alg` header is [optional](https://datatracker.ietf.org/doc/html/rfc7517#section-4.4), so some identity providers may not supply it (such as [Microsoft Identity](https://login.microsoftonline.com/common/discovery/v2.0/keys)).