### PR TITLE
Add a logger to log the calls to the Identity Provider

### DIFF
--- a/e2e/istio/istio_test.go
+++ b/e2e/istio/istio_test.go
@@ -39,7 +39,7 @@ func (i *IstioSuite) TestIstioEnforcement() {
 			// Initialize the test OIDC client that will keep track of the state of the OIDC login process
 			// Initialize it for each test to not reuse the session between them
 			client, err := e2e.NewOIDCTestClient(
-				e2e.WithLoggingOptions(i.T().Log, true),
+				e2e.WithLoggingOptions(i.T().Log),
 				e2e.WithCustomCA(testCAFile),
 				// Map the keycloak cluster DNS name to the local address where the service is exposed
 				e2e.WithCustomAddressMappings(map[string]string{

--- a/e2e/keycloak/keycloak_test.go
+++ b/e2e/keycloak/keycloak_test.go
@@ -51,7 +51,7 @@ var (
 func TestOIDCUsesTheConfiguredProxy(t *testing.T) {
 	client, err := e2e.NewOIDCTestClient(
 		e2e.WithCustomCA(testCAFile),
-		e2e.WithLoggingOptions(t.Log, true),
+		e2e.WithLoggingOptions(t.Log),
 		e2e.WithCustomAddressMappings(customAddressMappings),
 	)
 	require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestOIDC(t *testing.T) {
 	// Initialize the test OIDC client that will keep track of the state of the OIDC login process
 	client, err := e2e.NewOIDCTestClient(
 		e2e.WithCustomCA(testCAFile),
-		e2e.WithLoggingOptions(t.Log, true),
+		e2e.WithLoggingOptions(t.Log),
 		e2e.WithCustomAddressMappings(customAddressMappings),
 	)
 	require.NoError(t, err)
@@ -109,7 +109,7 @@ func TestOIDCRefreshTokens(t *testing.T) {
 	// Initialize the test OIDC client that will keep track of the state of the OIDC login process
 	client, err := e2e.NewOIDCTestClient(
 		e2e.WithCustomCA(testCAFile),
-		e2e.WithLoggingOptions(t.Log, true),
+		e2e.WithLoggingOptions(t.Log),
 		e2e.WithCustomAddressMappings(customAddressMappings),
 	)
 	require.NoError(t, err)
@@ -163,7 +163,7 @@ func TestOIDCLogout(t *testing.T) {
 	// Initialize the test OIDC client that will keep track of the state of the OIDC login process
 	client, err := e2e.NewOIDCTestClient(
 		e2e.WithCustomCA(testCAFile),
-		e2e.WithLoggingOptions(t.Log, true),
+		e2e.WithLoggingOptions(t.Log),
 		e2e.WithBaseURL(idpBaseURLHost),
 		e2e.WithCustomAddressMappings(customAddressMappings),
 	)

--- a/e2e/legacy/legacy_test.go
+++ b/e2e/legacy/legacy_test.go
@@ -51,7 +51,7 @@ func TestOIDC(t *testing.T) {
 	// Initialize the test OIDC client that will keep track of the state of the OIDC login process
 	client, err := e2e.NewOIDCTestClient(
 		e2e.WithCustomCA(testCAFile),
-		e2e.WithLoggingOptions(t.Log, true),
+		e2e.WithLoggingOptions(t.Log),
 		e2e.WithCustomAddressMappings(customAddressMappings),
 	)
 	require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestOIDCRefreshTokens(t *testing.T) {
 	// Initialize the test OIDC client that will keep track of the state of the OIDC login process
 	client, err := e2e.NewOIDCTestClient(
 		e2e.WithCustomCA(testCAFile),
-		e2e.WithLoggingOptions(t.Log, true),
+		e2e.WithLoggingOptions(t.Log),
 		e2e.WithCustomAddressMappings(customAddressMappings),
 	)
 	require.NoError(t, err)
@@ -131,7 +131,7 @@ func TestOIDCLogout(t *testing.T) {
 	// Initialize the test OIDC client that will keep track of the state of the OIDC login process
 	client, err := e2e.NewOIDCTestClient(
 		e2e.WithCustomCA(testCAFile),
-		e2e.WithLoggingOptions(t.Log, true),
+		e2e.WithLoggingOptions(t.Log),
 		e2e.WithBaseURL(idpBaseURLHost),
 		e2e.WithCustomAddressMappings(customAddressMappings),
 	)

--- a/internal/authz/oidc_test.go
+++ b/internal/authz/oidc_test.go
@@ -1370,7 +1370,7 @@ func TestAreTokensExpired(t *testing.T) {
 				tokResp.AccessTokenExpiresAt = tt.accessTokenExpiration
 			}
 
-			got, err := h.(*oidcHandler).areRequiredTokensExpired(tokResp)
+			got, err := h.(*oidcHandler).areRequiredTokensExpired(h.(*oidcHandler).log, tokResp)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})

--- a/internal/http/logging.go
+++ b/internal/http/logging.go
@@ -1,0 +1,51 @@
+// Copyright 2024 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) Tetrate, Inc 2024 All Rights Reserved.
+
+package http
+
+import (
+	"net/http"
+	"net/http/httputil"
+
+	"github.com/tetratelabs/telemetry"
+)
+
+// LoggingRoundTripper is a http.RoundTripper that logs requests and responses.
+type LoggingRoundTripper struct {
+	Log      telemetry.Logger
+	Delegate http.RoundTripper
+}
+
+// RoundTrip logs all the requests and responses using the configured settings.
+func (l LoggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if l.Log.Level() < telemetry.LevelDebug {
+		return l.Delegate.RoundTrip(req)
+	}
+
+	if dump, derr := httputil.DumpRequest(req, true); derr == nil {
+		l.Log.Debug("request", "data", string(dump))
+	}
+
+	res, err := l.Delegate.RoundTrip(req)
+
+	if err == nil {
+		if dump, derr := httputil.DumpResponse(res, true); derr == nil {
+			l.Log.Debug("response", "data", string(dump))
+		}
+	}
+
+	return res, err
+}

--- a/internal/http/logging_test.go
+++ b/internal/http/logging_test.go
@@ -1,0 +1,101 @@
+// Copyright 2024 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) Tetrate, Inc 2024 All Rights Reserved.
+
+package http
+
+import (
+	"bufio"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/telemetry"
+	"github.com/tetratelabs/telemetry/function"
+)
+
+const (
+	request  = "POST / HTTP/1.1\r\nHost: example.com\r\n\r\nreq body"
+	response = "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nresp body"
+)
+
+func TestLoggingRoundTripper(t *testing.T) {
+	var (
+		rt  = &recordedRoundTrip{logs: make([]logEntry, 0)}
+		lrt = LoggingRoundTripper{
+			Log: function.NewLogger(rt.log),
+			Delegate: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				return http.ReadResponse(bufio.NewReader(strings.NewReader(response)), req)
+			}),
+		}
+	)
+
+	tests := []struct {
+		name  string
+		level telemetry.Level
+		want  []logEntry
+	}{
+		{"no-debug", telemetry.LevelInfo, []logEntry{}},
+		{"debug", telemetry.LevelDebug, []logEntry{
+			{
+				level:  telemetry.LevelDebug,
+				msg:    "request",
+				values: []any{"data", request},
+			},
+			{
+				level:  telemetry.LevelDebug,
+				msg:    "response",
+				values: []any{"data", response},
+			},
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lrt.Log.SetLevel(tt.level)
+			req, err := http.NewRequest("POST", "http://example.com", strings.NewReader("req body"))
+			require.NoError(t, err)
+
+			_, err = lrt.RoundTrip(req)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, rt.logs)
+		})
+	}
+}
+
+type roundTripperFunc func(req *http.Request) (*http.Response, error)
+
+func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+type recordedRoundTrip struct {
+	logs []logEntry
+}
+
+type logEntry struct {
+	level  telemetry.Level
+	msg    string
+	values []any
+}
+
+func (r *recordedRoundTrip) log(level telemetry.Level, msg string, _ error, values function.Values) {
+	r.logs = append(r.logs, logEntry{
+		level:  level,
+		msg:    msg,
+		values: values.FromMethod,
+	})
+}

--- a/internal/logging.go
+++ b/internal/logging.go
@@ -32,6 +32,7 @@ const (
 	Config   = "config"
 	Default  = "default"
 	Health   = "health"
+	IDP      = "idp"
 	JWKS     = "jwks"
 	Requests = "requests"
 	Server   = "server"
@@ -45,6 +46,7 @@ var scopes = map[string]string{
 	Config:   "Configuration messages",
 	Default:  "Default",
 	Health:   "Health server messages",
+	IDP:      "Identity provider requests/responses",
 	JWKS:     "JWKS update and parse messages",
 	Requests: "Logs all requests and responses received by the server",
 	Server:   "Server request handling messages",
@@ -158,14 +160,15 @@ func setLogLevels(log telemetry.Logger, logLevelMap map[string]telemetry.Level) 
 		for _, logger := range scope.List() {
 			logger.SetLevel(level)
 		}
-	} else {
-		for k, l := range logLevelMap {
-			logger, ok := scope.Find(k)
-			if ok {
-				logger.SetLevel(l)
-			} else {
-				log.Info("invalid logger", "logger", k)
-			}
+		delete(logLevelMap, "all")
+	}
+
+	for k, l := range logLevelMap {
+		logger, ok := scope.Find(k)
+		if ok {
+			logger.SetLevel(l)
+		} else {
+			log.Info("invalid logger", "logger", k)
 		}
 	}
 }

--- a/internal/logging_test.go
+++ b/internal/logging_test.go
@@ -59,7 +59,7 @@ func TestLoggingSetup(t *testing.T) {
 		{"l1:debug", telemetry.LevelDebug, telemetry.LevelInfo, false},
 		{"l1:debug,l2:debug", telemetry.LevelDebug, telemetry.LevelDebug, false},
 		{"invalid:debug,l2:error", telemetry.LevelInfo, telemetry.LevelError, false},
-		{"all:none,l1:debug", telemetry.LevelNone, telemetry.LevelNone, false},
+		{"all:none,l1:debug", telemetry.LevelDebug, telemetry.LevelNone, false},
 		{"", telemetry.LevelInfo, telemetry.LevelInfo, false},
 		{",", telemetry.LevelInfo, telemetry.LevelInfo, true},
 		{":", telemetry.LevelInfo, telemetry.LevelInfo, true},

--- a/internal/oidc/memory.go
+++ b/internal/oidc/memory.go
@@ -70,6 +70,7 @@ func (m *memoryStore) GetTokenResponse(ctx context.Context, sessionID string) (*
 		return nil, nil
 	}
 
+	log.Debug("token response", "token_response", s.tokenResponse)
 	s.accessed = m.clock.Now()
 	return s.tokenResponse, nil
 }
@@ -96,6 +97,7 @@ func (m *memoryStore) GetAuthorizationState(ctx context.Context, sessionID strin
 		return nil, nil
 	}
 
+	log.Debug("authorization state", "state", s.authorizationState)
 	s.accessed = m.clock.Now()
 	return s.authorizationState, nil
 }

--- a/internal/oidc/redis.go
+++ b/internal/oidc/redis.go
@@ -152,6 +152,8 @@ func (r *redisStore) GetTokenResponse(ctx context.Context, sessionID string) (*T
 		return nil, err
 	}
 
+	log.Debug("token response", "token_response", tokenResponse)
+
 	return tokenResponse, nil
 }
 
@@ -198,6 +200,8 @@ func (r *redisStore) GetAuthorizationState(ctx context.Context, sessionID string
 	if err := r.refreshExpiration(ctx, sessionID, state.TimeAdded); err != nil {
 		return nil, err
 	}
+
+	log.Debug("authorization state", "state", state.AuthorizationState())
 
 	return state.AuthorizationState(), nil
 }


### PR DESCRIPTION
This adds the `idp` logger that will log all the calls made to the Identity Provider such as the token endpoint calls. It also adds more information to some of the existing loggers. Currently, there are no means to see what requests are being made as part of the OIDC flow, and troubleshooting the responses from the IdP was challenging. This logger will facilitate better understand the flow.

It is important to note that the `idp` logger may expose sensitive information in the logs, such as the `client_secret` or the tokens being issued. Use with care and do not enable it by default. To make it easier to set default log levels and just override some, I've changed a bit the behavior of the logging settings, to allow things like: `all:debug,idp:none`. Previously, if the `all` logger was set, all the other log levels were ignored. Now, if the `all` logger is present, it will be used as the default, then individual loggers will be configured on top.

