### PR TITLE
Cache well-known responses to avoid making too much calls to the IdP

### DIFF
--- a/internal/authz/oidc_test.go
+++ b/internal/authz/oidc_test.go
@@ -1396,6 +1396,7 @@ func TestLoadWellKnownConfigMissingLogoutRedirectURI(t *testing.T) {
 	t.Cleanup(idpServer.Stop)
 
 	cfg := proto.Clone(dynamicOIDCConfig).(*oidcv1.OIDCConfig)
+	cfg.ConfigurationUri = "http://missing-logout/.well-known/openid-configuration"
 	require.ErrorIs(t, loadWellKnownConfig(idpServer.newHTTPClient(), cfg), ErrMissingLogoutRedirectURI)
 }
 
@@ -1403,6 +1404,7 @@ func TestLoadWellKnownConfigError(t *testing.T) {
 	clock := oidc.Clock{}
 	tlsPool := internal.NewTLSConfigPool(context.Background())
 	cfg := proto.Clone(dynamicOIDCConfig).(*oidcv1.OIDCConfig)
+	cfg.ConfigurationUri = "http://stopped-server/.well-known/openid-configuration"
 	sessions := &mockSessionStoreFactory{store: oidc.NewMemoryStore(&clock, time.Hour, time.Hour)}
 	_, err := NewOIDCHandler(cfg, tlsPool, oidc.NewJWKSProvider(newConfigFor(basicOIDCConfig), tlsPool),
 		sessions, clock, oidc.NewStaticGenerator(newSessionID, newNonce, newState))

--- a/internal/oidc/discovery_test.go
+++ b/internal/oidc/discovery_test.go
@@ -53,7 +53,7 @@ func TestWellKnownConfig(t *testing.T) {
 		{"ok", "http://example.com/.well-known/openid-configuration", validWellKnownJSON, false, validWellKnown},
 		{"not-found", "http://example.com/not-found", validWellKnownJSON, true, WellKnownConfig{}},
 		{"invalid-url", "invalid", validWellKnownJSON, true, WellKnownConfig{}},
-		{"invalid-json", "http://example.com/.well-known/openid-configuration", invalidWellKnownJSON, true, WellKnownConfig{}},
+		{"invalid-json", "http://example2.com/.well-known/openid-configuration", invalidWellKnownJSON, true, WellKnownConfig{}},
 	}
 
 	for _, tt := range tests {
@@ -72,6 +72,25 @@ func TestWellKnownConfig(t *testing.T) {
 			require.Equal(t, tt.wantConfig, got)
 		})
 	}
+}
+
+func TestWellKnownConfigCache(t *testing.T) {
+	s := newServer()
+	s.wellKnownConfig = validWellKnownJSON
+	s.Start()
+	c := s.newHTTPClient()
+
+	got, err := GetWellKnownConfig(c, "http://example.com/.well-known/openid-configuration")
+	require.NoError(t, err)
+	require.Equal(t, validWellKnown, got)
+
+	// Stop the server and run the well-known request again.
+	// It should succeed and return the cached value.
+	s.Stop()
+
+	got, err = GetWellKnownConfig(c, "http://example.com/.well-known/openid-configuration")
+	require.NoError(t, err)
+	require.Equal(t, validWellKnown, got)
 }
 
 type idpServer struct {


### PR DESCRIPTION
While working on https://github.com/istio-ecosystem/authservice/pull/250, I saw that authservice was calling many times the well-known endpoint for a single OIDC session. This is because we call it when initializing the OIDC handlers, and that is done per request to the Envoy ext-authz filter, and a single OIDC session may involve several requests, given the redirects, making several unnecessary calls to the IdP.

This PR caches the seen well-known requests, and returns them from the cache for subsequent requests. The well-known endpoints are usually stable and it is very rare that they change, so it should be fine to just cache them by default.