### PR TITLE
Add minimal examples to make it easier to get started

### DIFF
--- a/examples/minimal/authservice-config.yaml
+++ b/examples/minimal/authservice-config.yaml
@@ -1,0 +1,68 @@
+# Copyright 2024 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: client-secret
+type: Opaque
+stringData:
+  client-secret: "authservice-secret"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: authservice-config
+data:
+  config.json: |
+    {
+      "listen_address": "0.0.0.0",
+      "listen_port": "10003",
+      "log_level": "debug",
+      "allow_unmatched_requests": false,
+      "chains": [
+        {
+          "name": "oidc",
+          "filters": [
+            {
+              "oidc":
+              {
+                "configuration_uri": "https://OIDC_PROVIDER_WELLKNOWN_URI/.well-known/openid-configuration",
+                <!--
+                  REMOVE THIS COMMENT
+                  The `callback_url` must point to the application that is guarded behind the OIDC login.,
+                  The path can be "anything", as long as it is configured in the ingress Gateway or VirtualService,
+                  to be forwarded to the application (even when the application does not expose such path). The,
+                  Istio AuthorizationPolicy that intercepts traffic will intercept the calls to this path and forward,
+                  them appropriately to the authservice.
+                -->
+                "callback_uri": "https://APPLICATION_URI/callback",
+                "client_id": "authservice-client",
+                "client_secret_ref": {
+                  "namespace": "CHANGEME",
+                  "name": "client-secret"
+                },
+                "id_token": {
+                  "preamble": "Bearer",
+                  "header": "authorization"
+                },
+                "access_token": {
+                  "header": "x-access-token"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }

--- a/examples/minimal/authservice.yaml
+++ b/examples/minimal/authservice.yaml
@@ -1,0 +1,89 @@
+# Copyright 2024 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: authservice
+  labels:
+    app: authservice
+spec:
+  ports:
+    # Main port where the authservice listens for gRPC requests.
+    # This is the port that needs to be set when configuring the `extensionProviders`
+    # in the Istio configuration.ß
+    - port: 10003
+      targetPort: 10003
+      name: grpc-authservice
+      protocol: TCP
+    - port: 10004
+      targetPort: 10004
+      name: grpc-health
+      protocol: TCP
+  selector:
+    app: authservice
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: authservice
+  labels:
+    app: authservice
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authservice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: authservice
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: authservice
+        version: v1
+    spec:
+      serviceAccountName: authservice
+      containers:
+        - name: authservice
+          image: ghcr.io/istio-ecosystem/authservice/authservice:1.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: authz
+              containerPort: 10003
+              protocol: TCP
+            - name: health
+              containerPort: 10004
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/authservice
+          livenessProbe:
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            tcpSocket:
+              port: 10003
+          readinessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            httpGet:
+              port: 10004
+              path: /healthz
+      volumes:
+        - name: config
+          configMap:
+            name: authservice-config

--- a/examples/minimal/authz-policy.yaml
+++ b/examples/minimal/authz-policy.yaml
@@ -1,0 +1,31 @@
+# Copyright 2024 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: authservice
+  # Applying this policy to the application namespace will intercept all requests
+  # that get to the sidecars in the namespace and forward them to the Authservice.
+spec:
+  action: CUSTOM
+  provider:
+    # Name defined in the extensionProviders property in the MeshConfig
+    # (the `istio` ConfigMap in the istio-system namespace)
+    name: authservice-grpc
+  # A single empty rule will force all requests to be forwarded to the external
+  # authorization backend, as long as the workload is captured by the selectors
+  # configured above.
+  rules:
+    - {}

--- a/examples/minimal/authz-policy.yaml
+++ b/examples/minimal/authz-policy.yaml
@@ -12,20 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Set a policy to make sure all requests targeting services in the namespace where
+# this policy is applied, contain a token issued by the OIDC provider.
+apiVersion: security.istio.io/v1beta1
+kind: RequestAuthentication
+metadata:
+  name: example-authn
+spec:
+  jwtRules:
+    - issuer: "OIDC_PROVIDER_ISSUER"
+      jwksUri: "http://OIDC_PROVIDER_JWKS_URI" # can be omitted if the issuer has a well-known endpoint
+      forwardOriginalToken: true
+---
+# Set a policy to enforce that the token is present. The policy allows any subject, but it can be
+# further refined with constraints based on the JWT token claims.
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: authservice
-  # Applying this policy to the application namespace will intercept all requests
-  # that get to the sidecars in the namespace and forward them to the Authservice.
+  name: example-authz
 spec:
-  action: CUSTOM
-  provider:
-    # Name defined in the extensionProviders property in the MeshConfig
-    # (the `istio` ConfigMap in the istio-system namespace)
-    name: authservice-grpc
-  # A single empty rule will force all requests to be forwarded to the external
-  # authorization backend, as long as the workload is captured by the selectors
-  # configured above.
+  action: ALLOW
   rules:
-    - {}
+    - from:
+        - source:
+            requestPrincipals: ["*"]

--- a/examples/minimal/istiod-values.yaml
+++ b/examples/minimal/istiod-values.yaml
@@ -1,0 +1,24 @@
+# Copyright 2024 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Example Istiod values.yaml that configures the Authservice as an extension provider
+meshConfig:
+  extensionProviders:
+    # Configure the backend for the Auth Service provider that can be used in AuthorizationPolicies
+    # in CUSTOM mode.
+    - name: authservice-grpc
+      envoyExtAuthzGrpc:
+        # This must match the Kubernetes service and port where the authservice is listening.
+        service: "authservice.authservice.svc.cluster.local"
+        port: "10003"   # This port is the one to be set in the authservice config

--- a/examples/minimal/oidc-intercept-policy.yaml
+++ b/examples/minimal/oidc-intercept-policy.yaml
@@ -1,0 +1,31 @@
+# Copyright 2024 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: authservice
+  # Applying this policy to the application namespace will intercept all requests
+  # that get to the sidecars in the namespace and forward them to the Authservice.
+spec:
+  action: CUSTOM
+  provider:
+    # Name defined in the extensionProviders property in the MeshConfig
+    # (the `istio` ConfigMap in the istio-system namespace)
+    name: authservice-grpc
+  # A single empty rule will force all requests to be forwarded to the external
+  # authorization backend, as long as the workload is captured by the selectors
+  # configured above.
+  rules:
+    - {}

--- a/examples/minimal/rbac.yaml
+++ b/examples/minimal/rbac.yaml
@@ -1,0 +1,37 @@
+# Copyright 2024 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: authservice-secrets
+rules:
+  # Allow authservice to read the secrets in its namespace so it can read
+  # the OIDC client-secret from a Kubernetes secret instead of having it in clear text
+  # in the ConfigMap
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: authservice-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: authservice-secrets
+subjects:
+  - kind: ServiceAccount
+    name: authservice


### PR DESCRIPTION
The only configs we had are the `e2e` ones, but it may be hard to get there when you're just trying to get started.
Having a minimal set of configs that are easy to copy/paste will be very helpful.