### PR TITLE
Fix scan job configuration

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -51,7 +51,11 @@ jobs:
         id: scan
         with:
           image: local/authservice:scan-amd64
+          # Only fail the build on PRs. Do not fail the build on the scheduled run, to let the workflow
+          # continue and have the report uploaded.
+          fail-build: ${{ github.event_name != 'schedule' }}
       - run: cat ${{ steps.scan.outputs.sarif }}
+        if: always()  # Always print the report to the stdout.
       # Do not upload the security advisories on every commit or pull request.
       # Upload the security advisories only for the nightly scans.
       - uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
The upload job was not triggered int he scheduled scan, because the job was marked as failed.
This changes the config to only mark as failed the scans run as part of the PR checks.