### PR TITLE
Upgrade to Go 1.22.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/istio-ecosystem/authservice
 
-go 1.22.2
+go 1.22.4
 
 require (
 	github.com/alicebob/miniredis/v2 v2.31.1


### PR DESCRIPTION
There are some low CVEs reported in Go 1.22.2. This PR upgrades to the latest Go version to see if they're already fixed there.
https://github.com/istio-ecosystem/authservice/security/code-scanning