### PR TITLE
Upgrade to Go 1.22.5 to fix CVE-2024-24791

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/istio-ecosystem/authservice
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/alicebob/miniredis/v2 v2.31.1


### PR DESCRIPTION
Ref: https://github.com/istio-ecosystem/authservice/security/code-scanning/6
See: https://groups.google.com/g/golang-dev/c/t0rK-qHBqzY/m/6MMoAZkMAgAJ