### PR TITLE
Upgrade to Go 1.24.7 to fix CVE-2024-3566

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/istio-ecosystem/authservice
 
-go 1.24.6
+go 1.24.7
 
 require (
 	github.com/alicebob/miniredis/v2 v2.31.1


### PR DESCRIPTION
Upgrade to Go 1.24.7 to fix CVE-2024-3566